### PR TITLE
[Feat] 회원가입 시 UserSettings, UserHome, UserGrowth 엔티티도 생성 + RecordFont 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
@@ -1,13 +1,16 @@
 package com.mmc.bookduck.domain.user.controller;
 
 import com.mmc.bookduck.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "User", description = "User 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
     private final UserService userService;
+
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/RecordFont.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/RecordFont.java
@@ -1,0 +1,7 @@
+package com.mmc.bookduck.domain.user.entity;
+
+public enum RecordFont {
+    NANUMGOTHIC,
+    NANUMMYEONGJO,
+    RIDIBATANG
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/UserGrowth.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/UserGrowth.java
@@ -36,7 +36,7 @@ public class UserGrowth {
     }
 
     // 레벨업
-    public void levelUp() {
+    public void incrementLevel() {
         this.level += 1;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/UserSettings.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/UserSettings.java
@@ -22,6 +22,10 @@ public class UserSettings {
     @ColumnDefault("true")
     private boolean isFriendRequestEnabled;
 
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private RecordFont recordFont;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", unique = true, updatable = false)
     @NotNull
@@ -33,10 +37,16 @@ public class UserSettings {
         this.user = user;
         this.isPushAlarmEnabled = true;
         this.isFriendRequestEnabled = true;
+        this.recordFont = RecordFont.NANUMGOTHIC;
     }
 
-    public void updateSettings(boolean isPushAlarmEnabled, boolean isFriendRequestEnabled) {
+    public void updateIsPushAlarmEnabled(boolean isPushAlarmEnabled) {
         this.isPushAlarmEnabled = isPushAlarmEnabled;
+    }
+    public void updateIsFriendRequestEnabled(boolean isFriendRequestEnabled) {
         this.isFriendRequestEnabled = isFriendRequestEnabled;
+    }
+    public void updateRecordFont(RecordFont recordFont) {
+        this.recordFont = recordFont;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/HomeBlockRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/HomeBlockRepository.java
@@ -1,0 +1,7 @@
+package com.mmc.bookduck.domain.user.repository;
+
+import com.mmc.bookduck.domain.user.entity.HomeBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HomeBlockRepository extends JpaRepository<HomeBlock, Long> {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserGrowthRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserGrowthRepository.java
@@ -1,0 +1,7 @@
+package com.mmc.bookduck.domain.user.repository;
+
+import com.mmc.bookduck.domain.user.entity.UserGrowth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGrowthRepository extends JpaRepository<UserGrowth, Long> {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserHomeRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserHomeRepository.java
@@ -1,0 +1,7 @@
+package com.mmc.bookduck.domain.user.repository;
+
+import com.mmc.bookduck.domain.user.entity.UserHome;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserHomeRepository extends JpaRepository<UserHome, Long> {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserSettingsRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserSettingsRepository.java
@@ -1,0 +1,7 @@
+package com.mmc.bookduck.domain.user.repository;
+
+import com.mmc.bookduck.domain.user.entity.UserSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSettingsRepository extends JpaRepository<UserSettings, Long> {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
@@ -76,13 +76,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             // 새로운 User 생성
             User newUser = oAuth2Attributes.toEntity(nickname);
 
+            // 새로운 User를 먼저 저장
+            newUser = userRepository.save(newUser);
+
             // 새로운 User의 UserSettings, UserHome, UserGrowth 생성
             UserSettings userSettings = UserSettings.builder().user(newUser).build();
             UserHome userHome = UserHome.builder().user(newUser).build();
             UserGrowth userGrowth = UserGrowth.builder().user(newUser).build();
 
             // 각 Repository에 저장
-            userRepository.save(oAuth2Attributes.toEntity(nickname));
             userSettingsRepository.save(userSettings);
             userHomeRepository.save(userHome);
             userGrowthRepository.save(userGrowth);

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
@@ -1,7 +1,13 @@
 package com.mmc.bookduck.global.oauth2;
 
 import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.entity.UserGrowth;
+import com.mmc.bookduck.domain.user.entity.UserHome;
+import com.mmc.bookduck.domain.user.entity.UserSettings;
+import com.mmc.bookduck.domain.user.repository.UserGrowthRepository;
+import com.mmc.bookduck.domain.user.repository.UserHomeRepository;
 import com.mmc.bookduck.domain.user.repository.UserRepository;
+import com.mmc.bookduck.domain.user.repository.UserSettingsRepository;
 import com.mmc.bookduck.global.exception.CustomOAuth2AuthenticationException;
 import com.mmc.bookduck.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +28,9 @@ import java.util.UUID;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
+    private final UserSettingsRepository userSettingsRepository;
+    private final UserHomeRepository userHomeRepository;
+    private final UserGrowthRepository userGrowthRepository;
 
     @Override
     @Transactional
@@ -49,23 +58,36 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Transactional
     public User getOrSave(OAuth2Attributes oAuth2Attributes) {
         String email = oAuth2Attributes.getEmail();
-        User user = userRepository.findByEmail(email).orElse(null);
+        User emailUser = userRepository.findByEmail(email).orElse(null);
 
         // 해당 이메일로 가입한 유저가 존재하는지 확인
-        if (user != null) {
+        if (emailUser != null) {
             // 이미 존재하는 유저의 로그인 유형과 현재 로그인 유형이 다르면 에러 발생
-            if (!user.getLoginType().equals(oAuth2Attributes.getLoginType())) {
+            if (!emailUser.getLoginType().equals(oAuth2Attributes.getLoginType())) {
                 throw new CustomOAuth2AuthenticationException(ErrorCode.EMAIL_ALREADY_REGISTERED);
             }
-            // 첫 로그인이 아님을 설정
             oAuth2Attributes.setFirstLogin(false);
-            return user;
+            return emailUser;
         } else {
             // 존재하지 않을 경우 새로운 유저 엔티티 생성. 랜덤 닉네임을 중복되지 않게 생성
             String nickname = generateUniqueNickname();
-            // 첫 로그인임을 설정
             oAuth2Attributes.setFirstLogin(true);
-            return userRepository.save(oAuth2Attributes.toEntity(nickname));
+
+            // 새로운 User 생성
+            User newUser = oAuth2Attributes.toEntity(nickname);
+
+            // 새로운 User의 UserSettings, UserHome, UserGrowth 생성
+            UserSettings userSettings = UserSettings.builder().user(newUser).build();
+            UserHome userHome = UserHome.builder().user(newUser).build();
+            UserGrowth userGrowth = UserGrowth.builder().user(newUser).build();
+
+            // 각 Repository에 저장
+            userRepository.save(oAuth2Attributes.toEntity(nickname));
+            userSettingsRepository.save(userSettings);
+            userHomeRepository.save(userHome);
+            userGrowthRepository.save(userGrowth);
+
+            return newUser;
         }
     }
 


### PR DESCRIPTION
# 구현 기능
  - 회원가입 과정에서 User 엔티티를 생성해 저장할 때, UserSettings, UserHome, UserGrowth 엔티티도 생성해 저장해야 해서 CustomOAuth2UserService 로직을 수정했습니다.
  - 유저 설정에 기록 폰트 설정 기능이 추가되어 RecordFont 이넘을 만들었습니다. (ERD 업데이트 완료)
  - 필요한 Repository들을 만들었습니다.
  - UserGrowth의 레벨을 올리는 메소드명을 incrementLevel()로 조금 더 직관적으로 바꿨습니다.
  - **Pull을 내려받으신 후 User 테이블 데이터들을/또는 전체 스키마를 한번 drop 후 개발 진행해주시면 감사드리겠습니다...**

# Resolve
  - #14