### PR TITLE
[Feat] folder 관련 API 구현

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
@@ -70,7 +70,7 @@ public class UserBookService {
 
     // 서재에서 책 삭제
     public String deleteUserBook(Long userBookId) {
-        UserBook userBook = findUserById(userBookId);
+        UserBook userBook = findUserBookById(userBookId);
 
         //임시 User
         Long userId = findUser().getUserId();
@@ -99,7 +99,7 @@ public class UserBookService {
             throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
         }
 
-        UserBook userBook = findUserById(userBookId);
+        UserBook userBook = findUserBookById(userBookId);
 
         //임시 User
         Long userId = findUser().getUserId();
@@ -114,7 +114,7 @@ public class UserBookService {
         }
     }
 
-    public UserBook findUserById(Long userBookId){
+    public UserBook findUserBookById(Long userBookId){
         UserBook userBook = userBookRepository.findById(userBookId)
                 .orElseThrow(()-> new CustomException(ErrorCode.USERBOOK_NOT_FOUND));
         return userBook;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
@@ -1,0 +1,87 @@
+package com.mmc.bookduck.domain.folder.controller;
+
+import com.mmc.bookduck.domain.folder.dto.request.FolderRequestDto;
+import com.mmc.bookduck.domain.folder.dto.response.AllFolderListResponseDto;
+import com.mmc.bookduck.domain.folder.dto.response.FolderBookListResponseDto;
+import com.mmc.bookduck.domain.folder.dto.response.FolderResponseDto;
+import com.mmc.bookduck.domain.folder.service.FolderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/folders")
+public class FolderController {
+    private final FolderService folderService;
+
+    // 폴더생성
+    @PostMapping
+    public ResponseEntity<FolderResponseDto> createFolder(@RequestBody FolderRequestDto dto){
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(folderService.createFolder(dto));
+    }
+
+    //폴더 수정
+    @PatchMapping("/{folderId}")
+    public ResponseEntity<FolderResponseDto> updateFolder(@PathVariable final Long folderId,
+                                                          @RequestBody FolderRequestDto dto){
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(folderService.updateFolder(folderId, dto));
+    }
+
+    // 폴더 삭제
+    @DeleteMapping("/{folderId}")
+    public ResponseEntity<String> deleteFolder(@PathVariable(name = "folderId") final Long folderId){
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(folderService.deleteFolder(folderId));
+    }
+
+    // 폴더에 책 추가
+    @PostMapping("/{folderId}/books/{userbookId}")
+    public ResponseEntity<FolderBookListResponseDto> addFolderBook(@PathVariable(name="folderId") final Long folderId,
+                                                                   @PathVariable(name="userbookId") final Long userBookId){
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(folderService.addFolderBook(folderId, userBookId));
+    }
+
+    /*
+    // 폴더에 추가할 후보 책 리스트 조회
+    @GetMapping("/{folderId}/books/candidates")
+    public ResponseEntity<CandidateFolderBookListResponseDto> getCandidateBooks(@PathVariable(name="folderId") final Long folderId){
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(folderService.getCandidateBooks(folderId));
+    }
+    */
+
+
+    //폴더에서 책 삭제
+    @DeleteMapping("/{folderId}/books/{folderbookId}")
+    public ResponseEntity<FolderBookListResponseDto> deleteFolderBook(@PathVariable(name="folderId") final Long folderId,
+                                                                      @PathVariable(name="folderbookId") final Long folderBookId){
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(folderService.deleteFolderBook(folderId, folderBookId));
+    }
+
+    //폴더 리스트 조회
+    @GetMapping("/list")
+    public ResponseEntity<AllFolderListResponseDto> getAllFolderList(){
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(folderService.getAllFolderList());
+    }
+
+    //폴더별 책 목록 조회
+    @GetMapping("/{folderId}/books")
+    public ResponseEntity<FolderBookListResponseDto> getFolderBookList(@PathVariable(name="folderId") final Long folderId){
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body((folderService.getFolderBookList(folderId)));
+    }
+
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
@@ -84,4 +84,13 @@ public class FolderController {
                 .body((folderService.getFolderBookList(folderId)));
     }
 
+    //폴더별&상태별 책 목록 조회
+    @GetMapping("/{folderId}/books/filter")
+    public ResponseEntity<FolderBookListResponseDto> getFolderBookListStatus(@PathVariable(name="folderId") final Long folderId,
+                                                                       @RequestParam(name="status") final String status){
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body((folderService.getFolderBookListStatus(folderId, status)));
+    }
+
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverDto.java
@@ -1,0 +1,4 @@
+package com.mmc.bookduck.domain.folder.dto.common;
+
+public record FolderBookCoverDto(Long folderBookId, Long userBookId, String imgPath) {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverListDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverListDto.java
@@ -2,6 +2,7 @@ package com.mmc.bookduck.domain.folder.dto.common;
 
 import com.mmc.bookduck.domain.folder.entity.Folder;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
+import com.mmc.bookduck.domain.folder.dto.common.FolderBookCoverDto;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverListDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverListDto.java
@@ -1,0 +1,45 @@
+package com.mmc.bookduck.domain.folder.dto.common;
+
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.folder.entity.Folder;
+import com.mmc.bookduck.domain.folder.entity.FolderBook;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FolderBookCoverListDto {
+    private Long folderId;
+    private String folderName;
+    private List<FolderBookCoverDto> folderBookCoverList;
+    private int folderBookCount;
+
+    public static FolderBookCoverListDto from(Folder folder, List<FolderBook> folderBooks) {
+        List<FolderBookCoverDto> coverList = new ArrayList<>();
+
+        for (FolderBook book : folderBooks) {
+            coverList.add(new FolderBookCoverDto(book.getFolderBookId(), book.getUserBook().getUserBookId(), book.getUserBook().getBookInfo().getImgPath()));
+        }
+
+        return new FolderBookCoverListDto(
+                folder.getFolderId(),
+                folder.getFolderName(),
+                coverList,
+                coverList.size()
+        );
+    }
+}
+@Getter
+@AllArgsConstructor
+class FolderBookCoverDto {
+    private Long folderBookId;
+    private Long userBookId;
+    private String imgPath;
+}
+

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverListDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookCoverListDto.java
@@ -1,30 +1,21 @@
 package com.mmc.bookduck.domain.folder.dto.common;
 
-import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.folder.entity.Folder;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderBookCoverListDto {
-    private Long folderId;
-    private String folderName;
-    private List<FolderBookCoverDto> folderBookCoverList;
-    private int folderBookCount;
-
+public record FolderBookCoverListDto(Long folderId, String folderName, List<FolderBookCoverDto> folderBookCoverList, int folderBookCount) {
     public static FolderBookCoverListDto from(Folder folder, List<FolderBook> folderBooks) {
         List<FolderBookCoverDto> coverList = new ArrayList<>();
 
         for (FolderBook book : folderBooks) {
-            coverList.add(new FolderBookCoverDto(book.getFolderBookId(), book.getUserBook().getUserBookId(), book.getUserBook().getBookInfo().getImgPath()));
+            coverList.add(new FolderBookCoverDto(
+                    book.getFolderBookId(),
+                    book.getUserBook().getUserBookId(),
+                    book.getUserBook().getBookInfo().getImgPath()
+            ));
         }
 
         return new FolderBookCoverListDto(
@@ -35,11 +26,3 @@ public class FolderBookCoverListDto {
         );
     }
 }
-@Getter
-@AllArgsConstructor
-class FolderBookCoverDto {
-    private Long folderBookId;
-    private Long userBookId;
-    private String imgPath;
-}
-

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
@@ -1,24 +1,9 @@
 package com.mmc.bookduck.domain.folder.dto.common;
 
 import com.mmc.bookduck.domain.book.entity.ReadStatus;
-import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderBookUnitDto {
-    private Long folderBookId;
-    private Long userBookId;
-    private String title;
-    private String author;
-    private String imgPath;
-    private ReadStatus readStatus;
-
+public record FolderBookUnitDto(Long folderBookId, Long userBookId, String title, String author, String imgPath, ReadStatus readStatus) {
     public static FolderBookUnitDto from(FolderBook folderBook) {
         return new FolderBookUnitDto(
                 folderBook.getFolderBookId(),

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
@@ -1,0 +1,32 @@
+package com.mmc.bookduck.domain.folder.dto.common;
+
+import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.folder.entity.FolderBook;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FolderBookUnitDto {
+    private Long folderBookId;
+    private Long userBookId;
+    private String title;
+    private String author;
+    private String imgPath;
+    private ReadStatus readStatus;
+
+    public static FolderBookUnitDto from(FolderBook folderBook) {
+        return new FolderBookUnitDto(
+                folderBook.getFolderBookId(),
+                folderBook.getUserBook().getUserBookId(),
+                folderBook.getUserBook().getBookInfo().getTitle(),
+                folderBook.getUserBook().getBookInfo().getAuthor(),
+                folderBook.getUserBook().getBookInfo().getImgPath(),
+                folderBook.getUserBook().getReadStatus()
+        );
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/request/FolderRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/request/FolderRequestDto.java
@@ -1,11 +1,4 @@
 package com.mmc.bookduck.domain.folder.dto.request;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderRequestDto {
-    private String folderName;
+public record FolderRequestDto(String folderName) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/request/FolderRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/request/FolderRequestDto.java
@@ -1,0 +1,11 @@
+package com.mmc.bookduck.domain.folder.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FolderRequestDto {
+    private String folderName;
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/AllFolderListResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/AllFolderListResponseDto.java
@@ -1,0 +1,22 @@
+package com.mmc.bookduck.domain.folder.dto.response;
+
+import com.mmc.bookduck.domain.folder.dto.common.FolderBookCoverListDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AllFolderListResponseDto {
+    private int folderCount;
+    private List<FolderBookCoverListDto> allFolderList;
+
+    public AllFolderListResponseDto(List<FolderBookCoverListDto> allFolderList){
+        this.allFolderList = allFolderList;
+        this.folderCount = allFolderList.size();
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/AllFolderListResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/AllFolderListResponseDto.java
@@ -1,22 +1,11 @@
 package com.mmc.bookduck.domain.folder.dto.response;
 
 import com.mmc.bookduck.domain.folder.dto.common.FolderBookCoverListDto;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AllFolderListResponseDto {
-    private int folderCount;
-    private List<FolderBookCoverListDto> allFolderList;
-
-    public AllFolderListResponseDto(List<FolderBookCoverListDto> allFolderList){
-        this.allFolderList = allFolderList;
-        this.folderCount = allFolderList.size();
+public record AllFolderListResponseDto(int folderCount, List<FolderBookCoverListDto> allFolderList) {
+    public AllFolderListResponseDto(List<FolderBookCoverListDto> allFolderList) {
+        this(allFolderList.size(), allFolderList);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderBookListResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderBookListResponseDto.java
@@ -2,24 +2,11 @@ package com.mmc.bookduck.domain.folder.dto.response;
 
 import com.mmc.bookduck.domain.folder.dto.common.FolderBookUnitDto;
 import com.mmc.bookduck.domain.folder.entity.Folder;
-import lombok.*;
 
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderBookListResponseDto {
-    private Long folderId;
-    private String folderName;
-    private int folderBookCount;
-    private List<FolderBookUnitDto> folderBookList;
-
-
+public record FolderBookListResponseDto(Long folderId, String folderName, int folderBookCount, List<FolderBookUnitDto> folderBookList) {
     public FolderBookListResponseDto(Folder folder, List<FolderBookUnitDto> folderBookList) {
-        this.folderId = folder.getFolderId();
-        this.folderName = folder.getFolderName();
-        this.folderBookList = folderBookList;
-        this.folderBookCount = folderBookList.size();
+        this(folder.getFolderId(), folder.getFolderName(), folderBookList.size(), folderBookList);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderBookListResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderBookListResponseDto.java
@@ -1,0 +1,25 @@
+package com.mmc.bookduck.domain.folder.dto.response;
+
+import com.mmc.bookduck.domain.folder.dto.common.FolderBookUnitDto;
+import com.mmc.bookduck.domain.folder.entity.Folder;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FolderBookListResponseDto {
+    private Long folderId;
+    private String folderName;
+    private int folderBookCount;
+    private List<FolderBookUnitDto> folderBookList;
+
+
+    public FolderBookListResponseDto(Folder folder, List<FolderBookUnitDto> folderBookList) {
+        this.folderId = folder.getFolderId();
+        this.folderName = folder.getFolderName();
+        this.folderBookList = folderBookList;
+        this.folderBookCount = folderBookList.size();
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderResponseDto.java
@@ -1,16 +1,8 @@
 package com.mmc.bookduck.domain.folder.dto.response;
 
 import com.mmc.bookduck.domain.folder.entity.Folder;
-import lombok.*;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FolderResponseDto {
-    private Long folderId;
-    private String folderName;
-    private Long userId;
-
+public record FolderResponseDto(Long folderId, String folderName, Long userId) {
     public static FolderResponseDto from(Folder savedFolder) {
         return new FolderResponseDto(savedFolder.getFolderId(), savedFolder.getFolderName(), savedFolder.getUser().getUserId());
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/response/FolderResponseDto.java
@@ -1,0 +1,17 @@
+package com.mmc.bookduck.domain.folder.dto.response;
+
+import com.mmc.bookduck.domain.folder.entity.Folder;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FolderResponseDto {
+    private Long folderId;
+    private String folderName;
+    private Long userId;
+
+    public static FolderResponseDto from(Folder savedFolder) {
+        return new FolderResponseDto(savedFolder.getFolderId(), savedFolder.getFolderName(), savedFolder.getUser().getUserId());
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/Folder.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/Folder.java
@@ -37,8 +37,11 @@ public class Folder {
         this.user = user;
         this.folderBooks = new ArrayList<>();
     }
+
     // folder 이름 수정
-    public void updateFolderName(String folderName) { this.folderName = folderName;}
+    public void updateFolderName(String folderName) {
+        this.folderName = folderName;
+    }
 
     // folderBook 추가
     public void addFolderBook(FolderBook folderBook) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/Folder.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/Folder.java
@@ -37,6 +37,8 @@ public class Folder {
         this.user = user;
         this.folderBooks = new ArrayList<>();
     }
+    // folder 이름 수정
+    public void updateFolderName(String folderName) { this.folderName = folderName;}
 
     // folderBook 추가
     public void addFolderBook(FolderBook folderBook) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/FolderBook.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/FolderBook.java
@@ -4,6 +4,7 @@ import com.mmc.bookduck.domain.book.entity.UserBook;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
@@ -28,6 +29,12 @@ public class FolderBook {
     @NotNull
     @OnDelete(action = OnDeleteAction.CASCADE) // 다대일 단방향이므로 설정
     private UserBook userBook;
+
+    @Builder
+    public FolderBook(UserBook userBook, Folder folder) {
+        this.folder = folder;
+        this.userBook = userBook;
+    }
 
     public void setFolder(Folder folder) {
         this.folder = folder;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderBookRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderBookRepository.java
@@ -1,7 +1,10 @@
 package com.mmc.bookduck.domain.folder.repository;
 
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.folder.entity.Folder;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FolderBookRepository extends JpaRepository<FolderBook, Long> {
+    boolean existsByUserBookAndFolder(UserBook userBook, Folder folder);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderRepository.java
@@ -1,7 +1,14 @@
 package com.mmc.bookduck.domain.folder.repository;
 
 import com.mmc.bookduck.domain.folder.entity.Folder;
+import com.mmc.bookduck.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+    Optional<Folder> findById(Long folderId);
+
+    List<Folder> findAllByUser(User user);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderBookService.java
@@ -1,0 +1,49 @@
+package com.mmc.bookduck.domain.folder.service;
+
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.folder.entity.Folder;
+import com.mmc.bookduck.domain.folder.entity.FolderBook;
+import com.mmc.bookduck.domain.folder.repository.FolderBookRepository;
+import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.global.exception.CustomException;
+import com.mmc.bookduck.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FolderBookService {
+    private final FolderBookRepository folderBookRepository;
+
+    // folderBook 생성
+    public FolderBook createFolderBook(UserBook userBook, Folder folder){
+        FolderBook folderBook = new FolderBook(userBook, folder);
+        return folderBookRepository.save(folderBook);
+    }
+
+    // 폴더삭제 시 folderBook 모두 삭제
+    public void deleteFolderBookList(Folder folder){
+        List<FolderBook> folderBookList = folder.getFolderBooks();
+        folderBookRepository.deleteAll(folderBookList);
+    }
+
+    // 폴더에서 책 삭제
+    public void deleteOneFolderBook(FolderBook folderBook){
+        folderBookRepository.delete(folderBook);
+    }
+
+    public boolean existsByUserBookAndFolder(UserBook userBook, Folder folder) {
+        return folderBookRepository.existsByUserBookAndFolder(userBook,folder);
+    }
+
+    public FolderBook findFolderBookById(Long folderBookId) {
+        FolderBook folderBook = folderBookRepository.findById(folderBookId)
+                .orElseThrow(()->new CustomException(ErrorCode.FOLDERBOOK_NOT_FOUND));
+        return folderBook;
+    }
+}
+

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderBookService.java
@@ -4,7 +4,6 @@ import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.folder.entity.Folder;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
 import com.mmc.bookduck.domain.folder.repository.FolderBookRepository;
-import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -118,6 +118,7 @@ public class FolderService {
     }
 
     // 폴더 별 도서 목록 조회
+    @Transactional(readOnly = true)
     public FolderBookListResponseDto getFolderBookList(Long folderId) {
         User user = userService.getCurrentUser();
         Folder folder = findFolderById(folderId);
@@ -136,6 +137,7 @@ public class FolderService {
     }
 
     // 전체 폴더 목록 조회
+    @Transactional(readOnly = true)
     public AllFolderListResponseDto getAllFolderList() {
         User user = userService.getCurrentUser();
         List<Folder> folders = folderRepository.findAllByUser(user);
@@ -150,6 +152,7 @@ public class FolderService {
         return new AllFolderListResponseDto(folderList);
     }
 
+    @Transactional(readOnly = true)
     public Folder findFolderById(Long folderId){
         Folder folder = folderRepository.findById(folderId)
                 .orElseThrow(()-> new CustomException(ErrorCode.FOLDER_NOT_FOUND));
@@ -157,6 +160,7 @@ public class FolderService {
     }
 
     // 폴더별 & 상태별 도서 목록 조회
+    @Transactional(readOnly = true)
     public FolderBookListResponseDto getFolderBookListStatus(Long folderId, String status) {
         User user = userService.getCurrentUser();
         Folder folder = findFolderById(folderId);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -156,6 +156,25 @@ public class FolderService {
         return folder;
     }
 
+    // 폴더별 & 상태별 도서 목록 조회
+    public FolderBookListResponseDto getFolderBookListStatus(Long folderId, String status) {
+        User user = userService.getCurrentUser();
+        Folder folder = findFolderById(folderId);
+
+        List<FolderBookUnitDto> folderBookList = new ArrayList<>();
+
+        if(folder.getUser().equals(user)){
+            for(FolderBook folderBook : folder.getFolderBooks()){
+                if(folderBook.getUserBook().getReadStatus().name().equals(status)){
+                    folderBookList.add(FolderBookUnitDto.from(folderBook));
+                }
+            }
+            return new FolderBookListResponseDto(folder, folderBookList);
+        }else{
+            throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
+        }
+    }
+
 
     /*
     public CandidateFolderBookListResponseDto getCandidateBooks(Long folderId) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -44,7 +44,7 @@ public class FolderService {
     // 폴더 생성
     public FolderResponseDto createFolder(FolderRequestDto dto) {
         User user = findUser();
-        Folder folder = new Folder(dto.getFolderName(), user);
+        Folder folder = new Folder(dto.folderName(), user);
 
         Folder savedFolder = folderRepository.save(folder);
         return FolderResponseDto.from(savedFolder);
@@ -55,7 +55,7 @@ public class FolderService {
         User user = findUser();
         Folder folder = findFolderById(folderId);
 
-        folder.updateFolderName(dto.getFolderName());
+        folder.updateFolderName(dto.folderName());
         return FolderResponseDto.from(folder);
     }
 
@@ -167,6 +167,7 @@ public class FolderService {
                 .orElseThrow(()-> new CustomException(ErrorCode.FOLDER_NOT_FOUND));
         return folder;
     }
+
 
     /*
     public CandidateFolderBookListResponseDto getCandidateBooks(Long folderId) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -1,0 +1,179 @@
+package com.mmc.bookduck.domain.folder.service;
+
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.book.repository.UserBookRepository;
+import com.mmc.bookduck.domain.folder.dto.common.FolderBookCoverListDto;
+import com.mmc.bookduck.domain.folder.dto.request.FolderRequestDto;
+import com.mmc.bookduck.domain.folder.dto.response.AllFolderListResponseDto;
+import com.mmc.bookduck.domain.folder.dto.response.FolderBookListResponseDto;
+import com.mmc.bookduck.domain.folder.dto.common.FolderBookUnitDto;
+import com.mmc.bookduck.domain.folder.dto.response.FolderResponseDto;
+import com.mmc.bookduck.domain.folder.entity.Folder;
+import com.mmc.bookduck.domain.folder.entity.FolderBook;
+import com.mmc.bookduck.domain.folder.repository.FolderRepository;
+import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.repository.UserRepository;
+import com.mmc.bookduck.global.exception.CustomException;
+import com.mmc.bookduck.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FolderService {
+    private final FolderRepository folderRepository;
+    private final UserBookRepository userBookRepository;
+    private final FolderBookService folderBookService;
+
+    // 임시 User
+    private final UserRepository userRepository;
+
+    public User findUser(){
+        User user = userRepository.findById(1L)
+                .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
+        return user;
+    }
+    //
+
+
+    // 폴더 생성
+    public FolderResponseDto createFolder(FolderRequestDto dto) {
+        User user = findUser();
+        Folder folder = new Folder(dto.getFolderName(), user);
+
+        Folder savedFolder = folderRepository.save(folder);
+        return FolderResponseDto.from(savedFolder);
+    }
+
+    // 폴더명 수정
+    public FolderResponseDto updateFolder(Long folderId, FolderRequestDto dto) {
+        User user = findUser();
+        Folder folder = findFolderById(folderId);
+
+        folder.updateFolderName(dto.getFolderName());
+        return FolderResponseDto.from(folder);
+    }
+
+    // 폴더 삭제
+    public String deleteFolder(Long folderId) {
+        User user = findUser();
+        Folder folder = findFolderById(folderId);
+
+        // 권한확인
+        if(folder.getUser().equals(user)){
+            // 폴더 책들을 다 삭제
+            folderBookService.deleteFolderBookList(folder);
+            folderRepository.delete(folder);
+            return "폴더를 삭제했습니다.";
+        }else{
+            throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
+        }
+    }
+
+
+    // 폴더에 책 추가
+    public FolderBookListResponseDto addFolderBook(Long folderId, Long userBookId) {
+        User user = findUser();
+        Folder folder = findFolderById(folderId);
+        //수정필요
+        UserBook userBook = userBookRepository.findById(userBookId)
+                .orElseThrow(()-> new CustomException(ErrorCode.USERBOOK_NOT_FOUND));
+
+        List<FolderBookUnitDto> folderBookList = new ArrayList<>();
+
+        // 권한확인
+        if(folder.getUser().equals(user) && userBook.getUser().equals(user)){
+            if(folderBookService.existsByUserBookAndFolder(userBook, folder)){
+                // 이미 folderBook 있을 때,
+                throw new CustomException(ErrorCode.FOLDERBOOK_ALREADY_EXISTS);
+            }
+            FolderBook newFolderBook = folderBookService.createFolderBook(userBook, folder);
+            folder.addFolderBook(newFolderBook);
+
+            for(FolderBook folderBook : folder.getFolderBooks()){
+                folderBookList.add(FolderBookUnitDto.from(folderBook));
+            }
+            return new FolderBookListResponseDto(folder, folderBookList);
+        }else{
+            throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
+        }
+    }
+
+    // 폴더에서 책 삭제
+    public FolderBookListResponseDto deleteFolderBook(Long folderId, Long folderBookId) {
+        User user = findUser();
+        Folder folder = findFolderById(folderId);
+        FolderBook folderBook = folderBookService.findFolderBookById(folderBookId);
+
+        List<FolderBookUnitDto> folderBookList = new ArrayList<>();
+
+        // 권한확인
+        if(folder.getUser().equals(user) && folderBook.getUserBook().getUser().equals(user)){
+            folder.removeFolderBook(folderBook);
+            folderBookService.deleteOneFolderBook(folderBook);
+
+            for(FolderBook book : folder.getFolderBooks()){
+                folderBookList.add(FolderBookUnitDto.from(book));
+            }
+            return new FolderBookListResponseDto(folder, folderBookList);
+        }else{
+            throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
+        }
+    }
+
+    // 폴더 별 도서 목록 조회
+    public FolderBookListResponseDto getFolderBookList(Long folderId) {
+        User user = findUser();
+        Folder folder = findFolderById(folderId);
+
+        List<FolderBookUnitDto> folderBookList = new ArrayList<>();
+
+        if(folder.getUser().equals(user)){
+            for(FolderBook folderBook : folder.getFolderBooks()){
+                folderBookList.add(FolderBookUnitDto.from(folderBook));
+            }
+            return new FolderBookListResponseDto(folder, folderBookList);
+        }else{
+            throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
+        }
+
+    }
+
+    // 전체 폴더 목록 조회
+    public AllFolderListResponseDto getAllFolderList() {
+        User user = findUser();
+        List<Folder> folders = folderRepository.findAllByUser(user);
+
+        List<FolderBookCoverListDto> folderList = new ArrayList<>();
+
+        if(folders == null){
+            return new AllFolderListResponseDto(folderList);
+        }
+        else{
+            for(Folder folder : folders){
+                folderList.add(FolderBookCoverListDto.from(folder, folder.getFolderBooks()));
+            }
+            return new AllFolderListResponseDto(folderList);
+        }
+    }
+
+    public Folder findFolderById(Long folderId){
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(()-> new CustomException(ErrorCode.FOLDER_NOT_FOUND));
+        return folder;
+    }
+
+    /*
+    public CandidateFolderBookListResponseDto getCandidateBooks(Long folderId) {
+        Folder folder = findFolderById(folderId);
+
+        //folder
+        //return new CandidateFolderBookListResponseDto(folderId, coverList);
+    }
+    */
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -13,6 +13,7 @@ import com.mmc.bookduck.domain.folder.entity.FolderBook;
 import com.mmc.bookduck.domain.folder.repository.FolderRepository;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.repository.UserRepository;
+import com.mmc.bookduck.domain.user.service.UserService;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -29,21 +30,12 @@ public class FolderService {
     private final FolderRepository folderRepository;
     private final UserBookRepository userBookRepository;
     private final FolderBookService folderBookService;
-
-    // 임시 User
-    private final UserRepository userRepository;
-
-    public User findUser(){
-        User user = userRepository.findById(1L)
-                .orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
-        return user;
-    }
-    //
+    private final UserService userService;
 
 
     // 폴더 생성
     public FolderResponseDto createFolder(FolderRequestDto dto) {
-        User user = findUser();
+        User user = userService.getCurrentUser();
         Folder folder = new Folder(dto.folderName(), user);
 
         Folder savedFolder = folderRepository.save(folder);
@@ -52,7 +44,7 @@ public class FolderService {
 
     // 폴더명 수정
     public FolderResponseDto updateFolder(Long folderId, FolderRequestDto dto) {
-        User user = findUser();
+        User user = userService.getCurrentUser();
         Folder folder = findFolderById(folderId);
 
         folder.updateFolderName(dto.folderName());
@@ -61,7 +53,7 @@ public class FolderService {
 
     // 폴더 삭제
     public String deleteFolder(Long folderId) {
-        User user = findUser();
+        User user = userService.getCurrentUser();
         Folder folder = findFolderById(folderId);
 
         // 권한확인
@@ -78,7 +70,7 @@ public class FolderService {
 
     // 폴더에 책 추가
     public FolderBookListResponseDto addFolderBook(Long folderId, Long userBookId) {
-        User user = findUser();
+        User user = userService.getCurrentUser();
         Folder folder = findFolderById(folderId);
         //수정필요
         UserBook userBook = userBookRepository.findById(userBookId)
@@ -106,7 +98,7 @@ public class FolderService {
 
     // 폴더에서 책 삭제
     public FolderBookListResponseDto deleteFolderBook(Long folderId, Long folderBookId) {
-        User user = findUser();
+        User user = userService.getCurrentUser();
         Folder folder = findFolderById(folderId);
         FolderBook folderBook = folderBookService.findFolderBookById(folderBookId);
 
@@ -128,7 +120,7 @@ public class FolderService {
 
     // 폴더 별 도서 목록 조회
     public FolderBookListResponseDto getFolderBookList(Long folderId) {
-        User user = findUser();
+        User user = userService.getCurrentUser();
         Folder folder = findFolderById(folderId);
 
         List<FolderBookUnitDto> folderBookList = new ArrayList<>();
@@ -146,20 +138,17 @@ public class FolderService {
 
     // 전체 폴더 목록 조회
     public AllFolderListResponseDto getAllFolderList() {
-        User user = findUser();
+        User user = userService.getCurrentUser();
         List<Folder> folders = folderRepository.findAllByUser(user);
 
         List<FolderBookCoverListDto> folderList = new ArrayList<>();
 
-        if(folders == null){
-            return new AllFolderListResponseDto(folderList);
-        }
-        else{
+        if(folders != null){
             for(Folder folder : folders){
                 folderList.add(FolderBookCoverListDto.from(folder, folder.getFolderBooks()));
             }
-            return new AllFolderListResponseDto(folderList);
         }
+        return new AllFolderListResponseDto(folderList);
     }
 
     public Folder findFolderById(Long folderId){

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -1,7 +1,7 @@
 package com.mmc.bookduck.domain.folder.service;
 
 import com.mmc.bookduck.domain.book.entity.UserBook;
-import com.mmc.bookduck.domain.book.repository.UserBookRepository;
+import com.mmc.bookduck.domain.book.service.UserBookService;
 import com.mmc.bookduck.domain.folder.dto.common.FolderBookCoverListDto;
 import com.mmc.bookduck.domain.folder.dto.request.FolderRequestDto;
 import com.mmc.bookduck.domain.folder.dto.response.AllFolderListResponseDto;
@@ -28,7 +28,7 @@ import java.util.List;
 @Transactional
 public class FolderService {
     private final FolderRepository folderRepository;
-    private final UserBookRepository userBookRepository;
+    private final UserBookService userBookService;
     private final FolderBookService folderBookService;
     private final UserService userService;
 
@@ -71,10 +71,9 @@ public class FolderService {
     // 폴더에 책 추가
     public FolderBookListResponseDto addFolderBook(Long folderId, Long userBookId) {
         User user = userService.getCurrentUser();
+
         Folder folder = findFolderById(folderId);
-        //수정필요
-        UserBook userBook = userBookRepository.findById(userBookId)
-                .orElseThrow(()-> new CustomException(ErrorCode.USERBOOK_NOT_FOUND));
+        UserBook userBook = userBookService.findUserBookById(userBookId);
 
         List<FolderBookUnitDto> folderBookList = new ArrayList<>();
 

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -53,9 +53,11 @@ public enum ErrorCode {
     EXCERPT_HEART_NOT_FOUND(404, "발췌의 좋아요를 찾을 수 없습니다."),
     ALARM_NOT_FOUND(404, "알림을 찾을 수 없습니다."),
     FOLDER_NOT_FOUND(404, "폴더를 찾을 수 없습니다."),
+    FOLDERBOOK_NOT_FOUND(404, "폴더내의 책을 찾을 수 없습니다."),
     BADGE_NOT_FOUND(404, "뱃지를 찾을 수 없습니다."),
     SKIN_NOT_FOUND(404, "스킨을 찾을 수 없습니다."),
     GENRE_NOT_FOUND(404, "장르를 찾을 수 없습니다."),
+
 
 
     // 409 Conflict
@@ -70,6 +72,7 @@ public enum ErrorCode {
     EXCERPT_ALREADY_EXISTS(409, "이미 존재하는 발췌입니다."),
     ALARM_ALREADY_EXISTS(409, "이미 존재하는 알림입니다."),
     FOLDER_ALREADY_EXISTS(409, "이미 존재하는 폴더입니다."),
+    FOLDERBOOK_ALREADY_EXISTS(409, "이미 폴더 내에 존재하는 책입니다."),
     BADGE_ALREADY_EXISTS(409, "이미 존재하는 뱃지입니다."),
     SKIN_ALREADY_EXISTS(409, "이미 존재하는 스킨입니다."),
     SKIN_ALREADY_EQUIPPED(409, "이미 장착한 스킨입니다."),


### PR DESCRIPTION
# 구현 기능
  - 폴더 생성, 폴더 이름 수정, 폴더 삭제 기능 구현했습니다.
  - 폴더를 삭제할 때, 해당 폴더의 folderBook을 모두 삭제하고 폴더 삭제하도록 했습니다.
  - 폴더에 책을 추가/삭제할 때, folderBookService에서 folderBook 생성/ 삭제하도록 했습니다.
  - 모든 폴더 리스트 조회에서는 피그마에 있는대로, 폴더정보와 폴더에 속하는 책들의 표지리스트 반환하도록 했습니다.

# Resolve
  - #19
