### PR TITLE
[Fix] JWT 토큰 발급에 role을 포함하도록 코드 수정

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
@@ -43,7 +43,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         User user = getOrSave(oAuth2Attributes);
 
         // OAuth2UserDetails 반환
-        return new OAuth2UserDetails(oAuth2UserAttributes, userNameAttributeName, user.getEmail(), oAuth2Attributes.isFirstLogin());
+        return new OAuth2UserDetails(oAuth2UserAttributes, userNameAttributeName, user.getEmail(), oAuth2Attributes.isFirstLogin(), user.getRole().name());
     }
 
     @Transactional

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2UserDetails.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2UserDetails.java
@@ -1,6 +1,5 @@
 package com.mmc.bookduck.global.oauth2;
 
-import com.mmc.bookduck.domain.user.entity.Role;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,7 +13,8 @@ public record OAuth2UserDetails(
         Map<String, Object> attributes,
         String attributeKey,
         String email,
-        boolean isFirstLogin // 첫 로그인 여부 추가
+        Boolean isFirstLogin, // 첫 로그인 여부
+        String role // 권한
 ) implements OAuth2User, UserDetails {
 
     @Override
@@ -29,8 +29,7 @@ public record OAuth2UserDetails(
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(
-                new SimpleGrantedAuthority(Role.ROLE_USER.toString()));
+        return Collections.singletonList(new SimpleGrantedAuthority(role)); // 권한 반환
     }
 
     @Override


### PR DESCRIPTION
# 구현 기능
  - 원인: 토큰의 클레임에 role을 안 넣어놀고 role을 꺼내려고 했음
  - 해결: JWT 토큰의 클레임에 role 정보를 포함하도록 코드를 수정했습니다

# Resolve
- #2 