### PR TITLE
[Fix] 소셜 로그인 성공 시 전달하는 쿼리파라미터 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
@@ -51,7 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         User user = getOrSave(oAuth2Attributes);
 
         // OAuth2UserDetails 반환
-        return new OAuth2UserDetails(oAuth2UserAttributes, userNameAttributeName, user.getEmail(), oAuth2Attributes.isFirstLogin(), user.getRole().name());
+        return new OAuth2UserDetails(oAuth2UserAttributes, userNameAttributeName, user.getEmail(), oAuth2Attributes.isNewUser(), user.getRole().name());
     }
 
     @Transactional

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2Attributes.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2Attributes.java
@@ -13,13 +13,13 @@ import java.util.Map;
 public class OAuth2Attributes {
     private LoginType loginType;
     private String email;
-    private boolean isFirstLogin;  // 첫 로그인 여부 필드 추가
+    private boolean isNewUser;
 
     @Builder
-    private OAuth2Attributes(String loginType, String email, boolean isFirstLogin) {
+    private OAuth2Attributes(String loginType, String email, boolean isNewUser) {
         this.loginType = LoginType.valueOf(loginType.toUpperCase());
         this.email = email;
-        this.isFirstLogin = isFirstLogin;  // 첫 로그인 여부 초기화
+        this.isNewUser = isNewUser;  // 신규 회원 여부
     }
 
     public static OAuth2Attributes of(String registrationId, Map<String, Object> attributes) {
@@ -34,7 +34,7 @@ public class OAuth2Attributes {
         return OAuth2Attributes.builder()
                 .loginType(registrationId)
                 .email(String.valueOf(attributes.get("email")))
-                .isFirstLogin(false)  // 초기값은 false로 설정
+                .isNewUser(false)  // 초기값은 false로 설정
                 .build();
     }
 
@@ -43,7 +43,7 @@ public class OAuth2Attributes {
         return OAuth2Attributes.builder()
                 .loginType(registrationId)
                 .email(String.valueOf(accountAttributes.get("email")))
-                .isFirstLogin(false)  // 초기값은 false로 설정
+                .isNewUser(false)  // 초기값은 false로 설정
                 .build();
     }
 
@@ -56,8 +56,8 @@ public class OAuth2Attributes {
                 .build();
     }
 
-    // 첫 로그인 여부를 설정하는 메서드
-    public void setFirstLogin(boolean isFirstLogin) {
-        this.isFirstLogin = isFirstLogin;
+    // 신규 회원 여부를 설정하는 메서드
+    public void setFirstLogin(boolean isNewUser) {
+        this.isNewUser = isNewUser;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2Attributes.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2Attributes.java
@@ -19,7 +19,7 @@ public class OAuth2Attributes {
     private OAuth2Attributes(String loginType, String email, boolean isNewUser) {
         this.loginType = LoginType.valueOf(loginType.toUpperCase());
         this.email = email;
-        this.isNewUser = isNewUser;  // 신규 회원 여부
+        this.isNewUser = isNewUser;  // 신규 유저 여부
     }
 
     public static OAuth2Attributes of(String registrationId, Map<String, Object> attributes) {
@@ -56,7 +56,7 @@ public class OAuth2Attributes {
                 .build();
     }
 
-    // 신규 회원 여부를 설정하는 메서드
+    // 신규 유저 여부를 설정하는 메서드
     public void setFirstLogin(boolean isNewUser) {
         this.isNewUser = isNewUser;
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
-    private static final String REDIRECT_URL = "http://localhost:3000"; // TODO: 추후 프론트엔드 배포 주소로 교체
+    private static final String REDIRECT_URL = "http://localhost:3000/home"; // TODO: 추후 프론트엔드 배포 주소로 교체
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
@@ -2,7 +2,6 @@ package com.mmc.bookduck.global.oauth2;
 
 import com.mmc.bookduck.global.security.CookieUtil;
 import com.mmc.bookduck.global.security.JwtUtil;
-import com.mmc.bookduck.global.security.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
@@ -19,8 +19,7 @@ import java.io.IOException;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
-    private static final String REDIRECT_URL = "http://localhost:3000"; // TODO: 추후 프론트엔드 로컬 주소로 교체
-    private static final String FIRST_LOGIN_REDIRECT_URL  = "http://localhost:3000/welcome"; // 첫 로그인(가입) 시 리디렉션할 URL
+    private static final String REDIRECT_URL = "http://localhost:3000"; // TODO: 추후 프론트엔드 배포 주소로 교체
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -28,28 +27,34 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         try {
             // 새로운 액세스 토큰 발급
             String accessToken = jwtUtil.generateAccessToken(authentication);
+            // 액세스 토큰 유효 시간
+            int accessTokenMaxAge = jwtUtil.getAccessTokenMaxAge();
+
              // 새로운 리프레시 토큰 발급
             String refreshToken = jwtUtil.generateRefreshToken(authentication);
 
             // 리프레시 토큰을 HttpOnly 쿠키에 저장
             cookieUtil.addCookie(response, "refreshToken", refreshToken, jwtUtil.getRefreshTokenMaxAge());
 
-            // OAuth2UserDetails를 통해 첫 로그인 여부 확인
+            // OAuth2UserDetails를 통해 신규 회원 여부 확인
             OAuth2UserDetails userDetails = (OAuth2UserDetails) authentication.getPrincipal();
-            boolean isFirstLogin = userDetails.isFirstLogin();
-
-            // 첫 로그인 여부에 따라 리디렉션 URL 다르게 설정
-            String redirectUrl = isFirstLogin ? FIRST_LOGIN_REDIRECT_URL : REDIRECT_URL;
+            boolean isNewUser = userDetails.isNewUser();
 
             // 로그 출력용
-            if (isFirstLogin) {
+            if (isNewUser) {
                 log.info("소셜 로그인-회원 가입에 성공하였습니다. 발급된 accessToken: {}", accessToken);
             } else {
                 log.info("소셜 로그인-가입된 계정으로 로그인 성공하였습니다. 발급된 accessToken: {}", accessToken);
             }
 
             // 액세스 토큰을 쿼리 파라미터로 전달하여 리디렉션
-            response.sendRedirect(redirectUrl + "?accessToken=" + accessToken);
+            String redirectUrl = UriComponentsBuilder.fromUriString(REDIRECT_URL)
+                    .queryParam("accessToken", accessToken)
+                    .queryParam("isNewUser", isNewUser)
+                    .queryParam("accessTokenMaxAge", accessTokenMaxAge)
+                    .build()
+                    .toUriString();
+            response.sendRedirect(redirectUrl);
         } catch (Exception e) {
             log.error("소셜 로그인 실패: {}", e.getMessage());
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "소셜 로그인 실패");

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
@@ -36,7 +36,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             // 리프레시 토큰을 HttpOnly 쿠키에 저장
             cookieUtil.addCookie(response, "refreshToken", refreshToken, jwtUtil.getRefreshTokenMaxAge());
 
-            // OAuth2UserDetails를 통해 신규 회원 여부 확인
+            // OAuth2UserDetails를 통해 신규 유저 여부 확인
             OAuth2UserDetails userDetails = (OAuth2UserDetails) authentication.getPrincipal();
             boolean isNewUser = userDetails.isNewUser();
 

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
@@ -28,11 +28,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             // 새로운 액세스 토큰 발급
             String accessToken = jwtUtil.generateAccessToken(authentication);
             // 액세스 토큰 유효 시간
-            int accessTokenMaxAge = jwtUtil.getAccessTokenMaxAge();
+            int expiresIn = jwtUtil.getAccessTokenMaxAge();
 
              // 새로운 리프레시 토큰 발급
             String refreshToken = jwtUtil.generateRefreshToken(authentication);
-
             // 리프레시 토큰을 HttpOnly 쿠키에 저장
             cookieUtil.addCookie(response, "refreshToken", refreshToken, jwtUtil.getRefreshTokenMaxAge());
 
@@ -50,8 +49,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             // 액세스 토큰을 쿼리 파라미터로 전달하여 리디렉션
             String redirectUrl = UriComponentsBuilder.fromUriString(REDIRECT_URL)
                     .queryParam("accessToken", accessToken)
+                    .queryParam("expiresIn", expiresIn)
                     .queryParam("isNewUser", isNewUser)
-                    .queryParam("accessTokenMaxAge", accessTokenMaxAge)
                     .build()
                     .toUriString();
             response.sendRedirect(redirectUrl);

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2UserDetails.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2UserDetails.java
@@ -13,7 +13,7 @@ public record OAuth2UserDetails(
         Map<String, Object> attributes,
         String attributeKey,
         String email,
-        Boolean isFirstLogin, // 첫 로그인 여부
+        Boolean isNewUser, // 신규 회원 여부
         String role // 권한
 ) implements OAuth2User, UserDetails {
 

--- a/bookduck/src/main/java/com/mmc/bookduck/global/security/JwtUtil.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/security/JwtUtil.java
@@ -24,7 +24,7 @@ public class JwtUtil {
     private final Key accessKey;
     private final Key refreshKey;
     private final RedisService redisService;
-    private static final Duration ACCESS_TOKEN_EXPIRE_TIME = Duration.ofHours(12); //12시간
+    private static final Duration ACCESS_TOKEN_EXPIRE_TIME = Duration.ofHours(6); //6시간
     private static final Duration REFRESH_TOKEN_EXPIRE_TIME = Duration.ofDays(7); //7일
 
     public JwtUtil(@Value("${jwt.secret.access}") String accessSecret, @Value("${jwt.secret.refresh}") String refreshSecret,


### PR DESCRIPTION
# 구현 기능
  - OAuthSuccessHandler에서 소셜 로그인 성공 시 동작을 프론트엔드 요구사항에 맞게 변경
  -  로그인 성공 시 리다이렉트 주소를 변경하는 대신, 쿼리 파라미터로 isNewUser를 전달
  - 신규 회원을 나타내는 변수명을 변경 (isFirstLogin->isNewUser)
  - 액세스 토큰의 유효 시간, expiresIn를 추가

# Resolve
  - #2 