### PR TITLE
[Feat] 아이템 관련 API 개발

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendRequestUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendRequestUnitDto.java
@@ -1,18 +1,17 @@
 package com.mmc.bookduck.domain.friend.dto.common;
 
 import com.mmc.bookduck.domain.friend.entity.FriendRequest;
-import com.mmc.bookduck.domain.item.dto.common.UserItemEquippedDto;
-import com.mmc.bookduck.domain.item.entity.ItemType;
+import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
 
-import java.util.Map;
+import java.util.List;
 
 public record FriendRequestUnitDto(
         Long requestId,
         Long userId,
         String userNickname,
-        Map<ItemType, Long> userItemEquipped
+        List<ItemEquippedUnitDto> userItemEquipped
 ) {
-    public static FriendRequestUnitDto from(FriendRequest friendRequest, Long userId, String userNickname, Map<ItemType, Long> userItemEquipped) {
+    public static FriendRequestUnitDto from(FriendRequest friendRequest, Long userId, String userNickname, List<ItemEquippedUnitDto> userItemEquipped) {
         return new FriendRequestUnitDto(
                 friendRequest.getRequestId(),
                 userId,

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendRequestUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendRequestUnitDto.java
@@ -2,14 +2,17 @@ package com.mmc.bookduck.domain.friend.dto.common;
 
 import com.mmc.bookduck.domain.friend.entity.FriendRequest;
 import com.mmc.bookduck.domain.item.dto.common.UserItemEquippedDto;
+import com.mmc.bookduck.domain.item.entity.ItemType;
+
+import java.util.Map;
 
 public record FriendRequestUnitDto(
         Long requestId,
         Long userId,
         String userNickname,
-        UserItemEquippedDto userItemEquipped
+        Map<ItemType, Long> userItemEquipped
 ) {
-    public static FriendRequestUnitDto from(FriendRequest friendRequest, Long userId, String userNickname, UserItemEquippedDto userItemEquipped) {
+    public static FriendRequestUnitDto from(FriendRequest friendRequest, Long userId, String userNickname, Map<ItemType, Long> userItemEquipped) {
         return new FriendRequestUnitDto(
                 friendRequest.getRequestId(),
                 userId,

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendUnitDto.java
@@ -2,14 +2,17 @@ package com.mmc.bookduck.domain.friend.dto.common;
 
 import com.mmc.bookduck.domain.friend.entity.Friend;
 import com.mmc.bookduck.domain.item.dto.common.UserItemEquippedDto;
+import com.mmc.bookduck.domain.item.entity.ItemType;
+
+import java.util.Map;
 
 public record FriendUnitDto(
         Long friendId, // 친구 삭제 기능
         Long userId,
         String nickname,
-        UserItemEquippedDto userItemEquipped
+        Map<ItemType, Long> userItemEquipped
 ) {
-    public static FriendUnitDto from(Friend friend, UserItemEquippedDto userItemEquipped) {
+    public static FriendUnitDto from(Friend friend, Map<ItemType, Long> userItemEquipped) {
         return new FriendUnitDto(
                 friend.getFriendId(),
                 friend.getUser2().getUserId(),

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendUnitDto.java
@@ -1,18 +1,17 @@
 package com.mmc.bookduck.domain.friend.dto.common;
 
 import com.mmc.bookduck.domain.friend.entity.Friend;
-import com.mmc.bookduck.domain.item.dto.common.UserItemEquippedDto;
-import com.mmc.bookduck.domain.item.entity.ItemType;
+import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
 
-import java.util.Map;
+import java.util.List;
 
 public record FriendUnitDto(
         Long friendId, // 친구 삭제 기능
         Long userId,
         String nickname,
-        Map<ItemType, Long> userItemEquipped
+        List<ItemEquippedUnitDto> userItemEquipped
 ) {
-    public static FriendUnitDto from(Friend friend, Map<ItemType, Long> userItemEquipped) {
+    public static FriendUnitDto from(Friend friend, List<ItemEquippedUnitDto> userItemEquipped) {
         return new FriendUnitDto(
                 friend.getFriendId(),
                 friend.getUser2().getUserId(),

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
@@ -74,7 +74,7 @@ public class FriendRequestService {
                         friendRequest,
                         friendRequest.getSender().getUserId(),
                         friendRequest.getSender().getNickname(),
-                        userItemService.getEquippedItemsOfUser(friendRequest.getSender())
+                        userItemService.getEquippedItemOfUserMap(friendRequest.getSender())
                 ))
                 .collect(Collectors.toList());
         return FriendRequestListResponseDto.from(receivedList);
@@ -90,7 +90,7 @@ public class FriendRequestService {
                         friendRequest,
                         friendRequest.getReceiver().getUserId(),
                         friendRequest.getReceiver().getNickname(),
-                        userItemService.getEquippedItemsOfUser(friendRequest.getReceiver())
+                        userItemService.getEquippedItemOfUserMap(friendRequest.getReceiver())
                 ))
                 .collect(Collectors.toList());
         return FriendRequestListResponseDto.from(sentList);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
@@ -74,7 +74,7 @@ public class FriendRequestService {
                         friendRequest,
                         friendRequest.getSender().getUserId(),
                         friendRequest.getSender().getNickname(),
-                        userItemService.getEquippedItemOrDefault(friendRequest.getSender().getUserId())
+                        userItemService.getEquippedItemsOfUser(friendRequest.getSender())
                 ))
                 .collect(Collectors.toList());
         return FriendRequestListResponseDto.from(receivedList);
@@ -90,7 +90,7 @@ public class FriendRequestService {
                         friendRequest,
                         friendRequest.getReceiver().getUserId(),
                         friendRequest.getReceiver().getNickname(),
-                        userItemService.getEquippedItemOrDefault(friendRequest.getReceiver().getUserId())
+                        userItemService.getEquippedItemsOfUser(friendRequest.getReceiver())
                 ))
                 .collect(Collectors.toList());
         return FriendRequestListResponseDto.from(sentList);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
@@ -74,7 +74,7 @@ public class FriendRequestService {
                         friendRequest,
                         friendRequest.getSender().getUserId(),
                         friendRequest.getSender().getNickname(),
-                        userItemService.getEquippedItemOfUserMap(friendRequest.getSender())
+                        userItemService.getUserItemEquippedListOfUser(friendRequest.getSender())
                 ))
                 .collect(Collectors.toList());
         return FriendRequestListResponseDto.from(receivedList);
@@ -90,7 +90,7 @@ public class FriendRequestService {
                         friendRequest,
                         friendRequest.getReceiver().getUserId(),
                         friendRequest.getReceiver().getNickname(),
-                        userItemService.getEquippedItemOfUserMap(friendRequest.getReceiver())
+                        userItemService.getUserItemEquippedListOfUser(friendRequest.getReceiver())
                 ))
                 .collect(Collectors.toList());
         return FriendRequestListResponseDto.from(sentList);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
@@ -60,10 +60,7 @@ public class FriendService {
         User currentUser = userService.getCurrentUser();
         List<FriendUnitDto> friendList = friendRepository.findAllByUser1UserId(currentUser.getUserId())
                 .stream()
-                .map(friend -> {
-                    UserItemEquippedDto userItemEquippedDto = userItemService.getEquippedItemsOfUser(friend.getUser2());
-                    return FriendUnitDto.from(friend, userItemEquippedDto);
-                })
+                .map(friend -> FriendUnitDto.from(friend, userItemService.getEquippedItemOfUserMap(friend.getUser2())))
                 .collect(Collectors.toList());
         return FriendListResponseDto.from(friendList);
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
@@ -8,7 +8,6 @@ import com.mmc.bookduck.domain.friend.entity.FriendRequest;
 import com.mmc.bookduck.domain.friend.entity.FriendRequestStatus;
 import com.mmc.bookduck.domain.friend.repository.FriendRepository;
 import com.mmc.bookduck.domain.friend.repository.FriendRequestRepository;
-import com.mmc.bookduck.domain.item.dto.common.UserItemEquippedDto;
 import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.service.UserService;
@@ -60,7 +59,7 @@ public class FriendService {
         User currentUser = userService.getCurrentUser();
         List<FriendUnitDto> friendList = friendRepository.findAllByUser1UserId(currentUser.getUserId())
                 .stream()
-                .map(friend -> FriendUnitDto.from(friend, userItemService.getEquippedItemOfUserMap(friend.getUser2())))
+                .map(friend -> FriendUnitDto.from(friend, userItemService.getUserItemEquippedListOfUser(friend.getUser2())))
                 .collect(Collectors.toList());
         return FriendListResponseDto.from(friendList);
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
@@ -61,7 +61,7 @@ public class FriendService {
         List<FriendUnitDto> friendList = friendRepository.findAllByUser1UserId(currentUser.getUserId())
                 .stream()
                 .map(friend -> {
-                    UserItemEquippedDto userItemEquippedDto = userItemService.getEquippedItemOrDefault(friend.getUser2().getUserId());
+                    UserItemEquippedDto userItemEquippedDto = userItemService.getEquippedItemsOfUser(friend.getUser2());
                     return FriendUnitDto.from(friend, userItemEquippedDto);
                 })
                 .collect(Collectors.toList());

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/controller/UserItemController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/controller/UserItemController.java
@@ -1,0 +1,31 @@
+package com.mmc.bookduck.domain.item.controller;
+
+import com.mmc.bookduck.domain.item.dto.request.UserItemUpdateRequestDto;
+import com.mmc.bookduck.domain.item.service.UserItemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Item", description = "Item 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/items")
+public class UserItemController {
+    private final UserItemService userItemService;
+
+    @Operation(summary = "캐릭터 아이템 옷장 조회", description = "캐릭터 아이템 옷장을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<?> getUserItemCloset() {
+        return ResponseEntity.ok(userItemService.getUserItemCloset());
+    }
+
+    @Operation(summary = "캐릭터 아이템 장착상태 변경", description = "캐릭터 아이템 장착상태를 변경합니다.")
+    @PatchMapping
+    public ResponseEntity<?> updateUserItemsEquippedStatus(@RequestBody @Valid UserItemUpdateRequestDto requestDto) {
+        userItemService.updateUserItemsEquippedStatus(requestDto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/controller/UserItemController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/controller/UserItemController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserItemController {
     private final UserItemService userItemService;
 
-    @Operation(summary = "캐릭터 아이템 옷장 조회", description = "캐릭터 아이템 옷장을 조회합니다.")
+    @Operation(summary = "캐릭터 꾸미기 아이템 조회", description = "캐릭터 꾸미기 아이템을 조회합니다.")
     @GetMapping
     public ResponseEntity<?> getUserItemCloset() {
         return ResponseEntity.ok(userItemService.getUserItemCloset());

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/ItemClosetUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/ItemClosetUnitDto.java
@@ -2,18 +2,25 @@ package com.mmc.bookduck.domain.item.dto.common;
 
 import com.mmc.bookduck.domain.item.entity.Item;
 import com.mmc.bookduck.domain.item.entity.ItemType;
+import com.mmc.bookduck.domain.item.entity.UserItem;
 
 public record ItemClosetUnitDto (
-        ItemType itemType,
         Long itemId,
+        ItemType itemType,
         Boolean isOwned,
+        Long userItemId,
         Boolean isEquipped
 ) {
-    public static ItemClosetUnitDto from(Item item, Boolean isOwned, Boolean isEquipped){
+    public static ItemClosetUnitDto from(Item item, UserItem userItem){
+        Long userItemId = (userItem != null) ? userItem.getUserItemId() : null;
+        Boolean isOwned = (userItem != null);
+        Boolean isEquipped = (userItem != null && userItem.isEquipped());
+
         return new ItemClosetUnitDto(
-                item.getItemType(),
                 item.getItemId(),
+                item.getItemType(),
                 isOwned,
+                userItemId,
                 isEquipped
         );
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/ItemClosetUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/ItemClosetUnitDto.java
@@ -1,0 +1,20 @@
+package com.mmc.bookduck.domain.item.dto.common;
+
+import com.mmc.bookduck.domain.item.entity.Item;
+import com.mmc.bookduck.domain.item.entity.ItemType;
+
+public record ItemClosetUnitDto (
+        ItemType itemType,
+        Long itemId,
+        Boolean isOwned,
+        Boolean isEquipped
+) {
+    public static ItemClosetUnitDto from(Item item, Boolean isOwned, Boolean isEquipped){
+        return new ItemClosetUnitDto(
+                item.getItemType(),
+                item.getItemId(),
+                isOwned,
+                isEquipped
+        );
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/ItemEquippedUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/ItemEquippedUnitDto.java
@@ -2,9 +2,8 @@ package com.mmc.bookduck.domain.item.dto.common;
 
 import com.mmc.bookduck.domain.item.entity.ItemType;
 
-import java.util.Map;
-
-public record UserItemEquippedDto(
-        Map<ItemType, Long> userItemEquipped
+public record ItemEquippedUnitDto(
+    ItemType itemType,
+    String itemName
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/UserItemEquippedDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/common/UserItemEquippedDto.java
@@ -5,6 +5,6 @@ import com.mmc.bookduck.domain.item.entity.ItemType;
 import java.util.Map;
 
 public record UserItemEquippedDto(
-        Map<ItemType, Long> equippedItems
+        Map<ItemType, Long> userItemEquipped
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemClosetResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemClosetResponseDto.java
@@ -1,0 +1,13 @@
+package com.mmc.bookduck.domain.item.dto.request;
+
+import com.mmc.bookduck.domain.item.dto.common.ItemClosetUnitDto;
+import com.mmc.bookduck.domain.item.entity.ItemType;
+
+import java.util.List;
+import java.util.Map;
+
+public record UserItemClosetResponseDto (
+    Map<ItemType, Long> equippedItems,
+    List<ItemClosetUnitDto> itemList
+) {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemUpdateRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemUpdateRequestDto.java
@@ -5,7 +5,7 @@ import com.mmc.bookduck.domain.item.entity.ItemType;
 import java.util.Map;
 
 public record UserItemUpdateRequestDto(
-        Map<ItemType, Long> equippedItems
+        Map<ItemType, Long> userItemEquipped
 ) {
 }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemUpdateRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemUpdateRequestDto.java
@@ -5,7 +5,7 @@ import com.mmc.bookduck.domain.item.entity.ItemType;
 import java.util.Map;
 
 public record UserItemUpdateRequestDto(
-        Map<ItemType, Long> userItemEquipped
+        Map<ItemType, Long> equippedUserItemIdList
 ) {
 }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemUpdateRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/request/UserItemUpdateRequestDto.java
@@ -1,10 +1,11 @@
-package com.mmc.bookduck.domain.item.dto.common;
+package com.mmc.bookduck.domain.item.dto.request;
 
 import com.mmc.bookduck.domain.item.entity.ItemType;
 
 import java.util.Map;
 
-public record UserItemEquippedDto(
+public record UserItemUpdateRequestDto(
         Map<ItemType, Long> equippedItems
 ) {
 }
+

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemClosetResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemClosetResponseDto.java
@@ -1,4 +1,4 @@
-package com.mmc.bookduck.domain.item.dto.request;
+package com.mmc.bookduck.domain.item.dto.response;
 
 import com.mmc.bookduck.domain.item.dto.common.ItemClosetUnitDto;
 import com.mmc.bookduck.domain.item.entity.ItemType;
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 public record UserItemClosetResponseDto (
-    Map<ItemType, Long> equippedItems,
+    Map<ItemType, Long> userItemEquipped,
     List<ItemClosetUnitDto> itemList
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemClosetResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemClosetResponseDto.java
@@ -1,13 +1,12 @@
 package com.mmc.bookduck.domain.item.dto.response;
 
 import com.mmc.bookduck.domain.item.dto.common.ItemClosetUnitDto;
-import com.mmc.bookduck.domain.item.entity.ItemType;
+import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
 
 import java.util.List;
-import java.util.Map;
 
 public record UserItemClosetResponseDto (
-    Map<ItemType, Long> userItemEquipped,
-    List<ItemClosetUnitDto> itemList
+        List<ItemEquippedUnitDto> userItemEquipped,
+        List<ItemClosetUnitDto> itemList
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemClosetResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemClosetResponseDto.java
@@ -1,12 +1,10 @@
 package com.mmc.bookduck.domain.item.dto.response;
 
 import com.mmc.bookduck.domain.item.dto.common.ItemClosetUnitDto;
-import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
 
 import java.util.List;
 
 public record UserItemClosetResponseDto (
-        List<ItemEquippedUnitDto> userItemEquipped,
         List<ItemClosetUnitDto> itemList
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemEquippedResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemEquippedResponseDto.java
@@ -5,6 +5,6 @@ import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
 import java.util.List;
 
 public record UserItemEquippedResponseDto(
-        List<ItemEquippedUnitDto> userItemEquipped
+        List<ItemEquippedUnitDto> itemEquipped
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemEquippedResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/dto/response/UserItemEquippedResponseDto.java
@@ -1,0 +1,10 @@
+package com.mmc.bookduck.domain.item.dto.response;
+
+import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
+
+import java.util.List;
+
+public record UserItemEquippedResponseDto(
+        List<ItemEquippedUnitDto> userItemEquipped
+) {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/entity/ItemType.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/entity/ItemType.java
@@ -1,6 +1,9 @@
 package com.mmc.bookduck.domain.item.entity;
 
 public enum ItemType {
-    NORMAL,
-    BADGE_REWARD
+    PROP,
+    HAT,
+    FACE,
+    CLOTHES,
+    BAG
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/repository/UserItemRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/repository/UserItemRepository.java
@@ -1,10 +1,12 @@
 package com.mmc.bookduck.domain.item.repository;
 
 import com.mmc.bookduck.domain.item.entity.UserItem;
+import com.mmc.bookduck.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface UserItemRepository extends JpaRepository<UserItem, Long> {
-    Optional<UserItem> findByUserUserIdAndIsEquippedTrue(Long userId);
+    List<UserItem> findAllByUserAndIsEquippedTrue(User user);
+    List<UserItem> findAllByUser(User user);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/ItemService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/ItemService.java
@@ -1,0 +1,20 @@
+package com.mmc.bookduck.domain.item.service;
+
+import com.mmc.bookduck.domain.item.entity.Item;
+import com.mmc.bookduck.domain.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ItemService {
+    private final ItemRepository itemRepository;
+
+    public List<Item> getAllItems() {
+        return itemRepository.findAll();
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
@@ -102,7 +102,14 @@ public class UserItemService {
     @Transactional(readOnly = true)
     public Map<ItemType, Long> getEquippedItemOfUserMap(User user) {
         List<UserItem> equippedItems = getAllUserItemsByUserAndIsEquippedTrue(user);
-        return equippedItems.stream()
+        Map<ItemType, Long> equippedItemMap = equippedItems.stream()
                 .collect(Collectors.toMap(userItem -> userItem.getItem().getItemType(), UserItem::getUserItemId));
+
+        // 기본적으로 ItemType별로 null을 추가
+        for (ItemType itemType : ItemType.values()) {
+            equippedItemMap.putIfAbsent(itemType, null); // 없으면 null을 할당
+        }
+
+        return equippedItemMap;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
@@ -52,7 +52,7 @@ public class UserItemService {
                 })
                 .collect(Collectors.toList());
 
-        return new UserItemClosetResponseDto(getUserItemEquippedListOfUser(user), itemList);
+        return new UserItemClosetResponseDto(itemList);
     }
 
     public void updateUserItemsEquippedStatus(UserItemUpdateRequestDto requestDto) {
@@ -64,12 +64,14 @@ public class UserItemService {
         userItemRepository.saveAll(equippedItems);
 
         // 새로 장착할 아이템 처리
-        Map<ItemType, Long> equippedItemMap = requestDto.userItemEquipped();
+        Map<ItemType, Long> equippedItemMap = requestDto.equippedUserItemIdList();
         equippedItemMap.forEach((itemType, userItemId) -> {
             if (userItemId != null) { // userItemId가 null인 경우 건너뜀
                 UserItem newItemToEquip = userItemRepository.findById(userItemId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USERITEM_NOT_FOUND));
-
+                if (!newItemToEquip.getUser().equals(user)) {
+                    throw new CustomException(ErrorCode.USERITEM_BAD_REQUEST);
+                }
                 if (newItemToEquip.getItem().getItemType() != itemType) {
                     throw new CustomException(ErrorCode.ITEMTYPE_MISMATCH);
                 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
@@ -1,21 +1,108 @@
 package com.mmc.bookduck.domain.item.service;
 
+import com.mmc.bookduck.domain.item.dto.common.ItemClosetUnitDto;
 import com.mmc.bookduck.domain.item.dto.common.UserItemEquippedDto;
+import com.mmc.bookduck.domain.item.dto.request.UserItemClosetResponseDto;
+import com.mmc.bookduck.domain.item.dto.request.UserItemUpdateRequestDto;
+import com.mmc.bookduck.domain.item.entity.Item;
+import com.mmc.bookduck.domain.item.entity.ItemType;
+import com.mmc.bookduck.domain.item.entity.UserItem;
 import com.mmc.bookduck.domain.item.repository.UserItemRepository;
+import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
-@RequiredArgsConstructor
 @Transactional
+@RequiredArgsConstructor
 public class UserItemService {
     private final UserItemRepository userItemRepository;
+    private final UserService userService;
+    private final ItemService itemService;
 
-    // 장착된 스킨 조회, 기본 스킨 처리
-    public UserItemEquippedDto getEquippedItemOrDefault(Long userId) {
-        return userItemRepository.findByUserUserIdAndIsEquippedTrue(userId)
-                .map(UserItemEquippedDto::from)
-                .orElseGet(() -> new UserItemEquippedDto(0L, 0L));  // 기본 스킨(=아무 장착도 하지 않은 상태)의 ID에 0 부여
+    // userId로 장착된 스킨 조회
+    @Transactional(readOnly = true)
+    public UserItemEquippedDto getEquippedItemsOfUserByUserId(Long userId) {
+        User user = userService.getUserByUserId(userId);
+        return new UserItemEquippedDto(getEquippedItemOfUserMap(user));
+    }
+
+    // user로 장착된 스킨 조회
+    @Transactional(readOnly = true)
+    public UserItemEquippedDto getEquippedItemsOfUser(User user) {
+        return new UserItemEquippedDto(getEquippedItemOfUserMap(user));
+    }
+
+    @Transactional(readOnly = true)
+    public UserItemClosetResponseDto getUserItemCloset() {
+        User user = userService.getCurrentUser();
+        List<Item> allItems = itemService.getAllItems();
+        List<UserItem> ownedItems = getAllUserItemsByUser(user);
+        Map<Long, UserItem> ownedUserItemMap = ownedItems.stream()
+                .collect(Collectors.toMap(userItem -> userItem.getItem().getItemId(), userItem -> userItem));
+
+        // 모든 아이템을 isOwned와 isEquipped 상태를 표시하여 DTO에 매핑
+        List<ItemClosetUnitDto> itemList = allItems.stream()
+                .map(item -> {
+                    UserItem userItem = ownedUserItemMap.get(item.getItemId());
+                    Boolean isOwned = (userItem != null);
+                    Boolean isEquipped = (userItem != null && userItem.isEquipped());
+                    return ItemClosetUnitDto.from(item, isOwned, isEquipped);
+                })
+                .collect(Collectors.toList());
+
+        return new UserItemClosetResponseDto(getEquippedItemOfUserMap(user), itemList);
+    }
+
+    public void updateUserItemsEquippedStatus(UserItemUpdateRequestDto requestDto) {
+        User user = userService.getCurrentUser();
+
+        // 과거 장착 아이템 해제
+        List<UserItem> equippedItems = userItemRepository.findAllByUserAndIsEquippedTrue(user);
+        equippedItems.forEach(item -> item.updateIsEquipped(false));
+
+        // 새 아이템 장착
+        Map<ItemType, Long> equippedItemMap = requestDto.equippedItems();
+        equippedItemMap.forEach((itemType, userItemId) -> {
+            UserItem newItemToEquip = userItemRepository.findById(userItemId)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid userItemId: " + userItemId));
+            if (newItemToEquip.getItem().getItemType() != itemType) {
+                throw new IllegalArgumentException("ItemType mismatch for userItemId: " + userItemId);
+            }
+            newItemToEquip.updateIsEquipped(true);
+        });
+
+        // 과거 장착 아이템 해제를 저장
+        userItemRepository.saveAll(equippedItems);
+
+        // 새 아이템 장착을 저장
+        equippedItemMap.values().forEach(userItemId -> {
+            UserItem item = userItemRepository.findById(userItemId)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid userItemId: " + userItemId));
+            userItemRepository.save(item);
+        });
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserItem> getAllUserItemsByUser(User user) {
+        return userItemRepository.findAllByUser(user);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserItem> getAllUserItemsByUserAndIsEquippedTrue(User user) {
+        return userItemRepository.findAllByUser(user);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<ItemType, Long> getEquippedItemOfUserMap(User user) {
+        List<UserItem> equippedItems = getAllUserItemsByUserAndIsEquippedTrue(user);
+        return equippedItems.stream()
+                .collect(Collectors.toMap(userItem -> userItem.getItem().getItemType(), UserItem::getUserItemId));
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.mmc.bookduck.domain.user.controller;
 
+import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.service.UserGrowthService;
 import com.mmc.bookduck.domain.user.service.UserReadingReportService;
 import com.mmc.bookduck.domain.user.service.UserService;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
     private final UserGrowthService userGrowthService;
+    private final UserItemService userItemService;
     private final UserReadingReportService userReadingReportService;
 
     @Operation(summary = "유저 검색", description = "유저를 검색합니다.")
@@ -38,6 +40,13 @@ public class UserController {
     public ResponseEntity<?> getUserGrowthInfo(@PathVariable final Long userId) {
         return ResponseEntity.ok().body(userGrowthService.getUserLevelInfo(userId));
     }
+
+    @Operation(summary = "유저 캐릭터가 착용한 아이템 조회", description = "유저 캐릭터가 착용한 아이템을 조회합니다.")
+    @GetMapping("/{userId}/character")
+    public ResponseEntity<?> getUserCharacterEquippedItems(@PathVariable final Long userId) {
+        return ResponseEntity.ok().body(userItemService.getEquippedItemsOfUserByUserId(userId));
+    }
+
 
     @Operation(summary = "유저 독서 리포트 조회 - 통계", description = "유저의 독서 리포트 중 통계를 조회합니다.")
     @GetMapping("/{userId}/statistics")

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_UNLOCK_CONDITION(400, "해제 조건이 잘못되었습니다."),
     // enum 값이 잘못됨
     INVALID_ENUM_VALUE(400, "enum 값이 잘못되었습니다."),
+    ITEMTYPE_MISMATCH(400,"ItemType이 맞지 않습니다."),
 
 
     // 401 Unauthorized
@@ -60,9 +61,8 @@ public enum ErrorCode {
     FOLDERBOOK_NOT_FOUND(404, "폴더내의 책을 찾을 수 없습니다."),
     BADGE_NOT_FOUND(404, "뱃지를 찾을 수 없습니다."),
     ITEM_NOT_FOUND(404, "아이템을 찾을 수 없습니다."),
+    USERITEM_NOT_FOUND(404, "유저의 아이템을 찾을 수 없습니다."),
     GENRE_NOT_FOUND(404, "장르를 찾을 수 없습니다."),
-
-
 
     // 409 Conflict
     // 중복 리소스 생성 시도
@@ -94,7 +94,8 @@ public enum ErrorCode {
     // Oauth2, JWT
     ILLEGAL_REGISTRATION_ID(500, "잘못된 registrationId입니다."),
     DATABASE_ERROR(500, "데이터베이스 오류가 발생했습니다."),
-    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다.")
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
+
     ;
 
     private final int status;

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // enum 값이 잘못됨
     INVALID_ENUM_VALUE(400, "enum 값이 잘못되었습니다."),
     ITEMTYPE_MISMATCH(400,"ItemType이 맞지 않습니다."),
+    USERITEM_BAD_REQUEST(400, "유저의 소유가 아닌 userItemId입니다."),
 
 
     // 401 Unauthorized


### PR DESCRIPTION
# 구현 기능
  - 유저 캐릭터가 착용한 아이템 조회 API
  - 캐릭터 아이템 옷장 조회 (소지 o/x 둘 다 전송) API
  - 캐릭터 아이템 장착상태 변경 API
  - 친구 목록 조회시 사용하는 Dto를 다음과 같은 형식으로 변경하였습니다.
```
public record UserItemEquippedDto(
        Map<ItemType, Long> userItemEquipped
) {
}
```
이에 따라 친구 목록 조회시에도 ItemType별 Map 형식으로 응답됩니다.

# Resolve
  - 이슈 태그(ex: #7)
