### PR TITLE
[Fix] folder 유효성검사 로직 수정 & 조회 오류 수정

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
@@ -28,22 +28,16 @@ public class FolderController {
     @PostMapping
     public ResponseEntity<FolderResponseDto> createFolder(@Valid @RequestBody FolderRequestDto dto, Errors error){
 
-        if(error.hasErrors()){
-            throw new CustomException(ErrorCode.INVALID_INPUT_LENGTH);
-        }
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(folderService.createFolder(dto));
+                .body(folderService.createFolder(dto, error));
     }
 
     @Operation(summary = "폴더 이름 수정", description = "폴더의 이름을 수정합니다.")
     @PatchMapping("/{folderId}")
     public ResponseEntity<FolderResponseDto> updateFolder(@PathVariable final Long folderId,
                                                           @Valid @RequestBody FolderRequestDto dto, Errors error){
-        if(error.hasErrors()){
-            throw new CustomException(ErrorCode.INVALID_INPUT_LENGTH);
-        }
         return ResponseEntity.status(HttpStatus.OK)
-                .body(folderService.updateFolder(folderId, dto));
+                .body(folderService.updateFolder(folderId, dto, error));
     }
 
     @Operation(summary = "폴더 삭제", description = "폴더를 삭제합니다.")

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -49,6 +49,9 @@ public class FolderService {
     // 폴더명 수정
     public FolderResponseDto updateFolder(Long folderId, FolderRequestDto dto) {
         User user = userService.getCurrentUser();
+        if(folderRepository.existsByFolderNameAndUser(dto.folderName(), user)){
+            throw new CustomException(ErrorCode.FOLDERNAME_ALREADY_EXISTS);
+        }
         Folder folder = findFolderById(folderId);
 
         folder.updateFolderName(dto.folderName());

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -196,16 +196,17 @@ public class FolderService {
 
         List<CandidateFolderBookDto> dtoList = new ArrayList<>();
 
+        List<UserBook> candidateList = new ArrayList<>(userBooks);
         for(UserBook userBook: userBooks){
             for(FolderBook folderBook: folderBooks){
                 if(userBook.equals(folderBook.getUserBook())){
-                    userBooks.remove(userBook);
+                    candidateList.remove(userBook);
                     break;
                 }
             }
         }
 
-        for(UserBook userBook: userBooks){
+        for(UserBook userBook: candidateList){
             dtoList.add(CandidateFolderBookDto.from(userBook));
         }
         return new CandidateFolderBookListResponseDto(dtoList);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.validation.Errors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +36,11 @@ public class FolderService {
 
 
     // 폴더 생성
-    public FolderResponseDto createFolder(FolderRequestDto dto) {
+    public FolderResponseDto createFolder(FolderRequestDto dto, Errors error) {
+        if(error.hasErrors()){
+            throw new CustomException(ErrorCode.INVALID_INPUT_LENGTH);
+        }
+
         User user = userService.getCurrentUser();
         if(folderRepository.existsByFolderNameAndUser(dto.folderName(), user)){
             throw new CustomException(ErrorCode.FOLDERNAME_ALREADY_EXISTS);
@@ -47,7 +52,11 @@ public class FolderService {
     }
 
     // 폴더명 수정
-    public FolderResponseDto updateFolder(Long folderId, FolderRequestDto dto) {
+    public FolderResponseDto updateFolder(Long folderId, FolderRequestDto dto, Errors error) {
+        if(error.hasErrors()){
+            throw new CustomException(ErrorCode.INVALID_INPUT_LENGTH);
+        }
+
         User user = userService.getCurrentUser();
         if(folderRepository.existsByFolderNameAndUser(dto.folderName(), user)){
             throw new CustomException(ErrorCode.FOLDERNAME_ALREADY_EXISTS);


### PR DESCRIPTION
# 구현 기능
  - folder 생성, 수정에서 requestDto 유효성 오류 반환 로직을 FolderService로 뺐습니다.
  - folder 수정할 때 folderName 중복 체크하는 로직 추가했습니다.
  - folder에 추가할 도서 목록 조회에서 발생하는 500 오류 수정했습니다.
       - java.util.ConcurrentModificationException : ArrayList를 순회하면서 동시에 해당 List를 수정하려고 할 때 오류가 발생-> List를 복사해서 수정은 복사한 List에서 진행하는 것으로 수정했습니다.

# Resolve
  - #71
