### PR TITLE
[Feat] 유저 검색 API 응답을 위한 로직, 로그인 성공 핸들러에 userId 반환 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/UserBadgeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/UserBadgeService.java
@@ -36,7 +36,7 @@ public class UserBadgeService {
 
     @Transactional(readOnly = true)
     public UserBadgeListResponseDto getUserBadges(Long userId) {
-        User user = userService.getUserByUserId(userId);
+        User user = userService.getActiveUserByUserId(userId);
         List<UserBadge> uniqueUserBadges = deleteDuplicateUserBadges(userBadgeRepository.findAllByUser(user));
 
         // 전체 뱃지

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
@@ -88,4 +88,10 @@ public class FriendService {
 
         friendRepository.delete(friend);
     }
+
+    @Transactional(readOnly = true)
+    public boolean isFriendWithCurrentUser(User otherUser) {
+        User currentUser = userService.getCurrentUser();
+        return friendRepository.findFriendBetweenUsers(currentUser.getUserId(), otherUser.getUserId()).isPresent();
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/item/service/UserItemService.java
@@ -29,10 +29,10 @@ public class UserItemService {
     private final UserService userService;
     private final ItemService itemService;
 
-    // userId로 장착된 스킨 조회
+    // userId로 장착된 아이템 조회
     @Transactional(readOnly = true)
     public UserItemEquippedResponseDto getEquippedItemsOfUserByUserId(Long userId) {
-        User user = userService.getUserByUserId(userId);
+        User user = userService.getActiveUserByUserId(userId);
         return new UserItemEquippedResponseDto(getUserItemEquippedListOfUser(user));
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.mmc.bookduck.domain.user.controller;
 import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.service.UserGrowthService;
 import com.mmc.bookduck.domain.user.service.UserReadingReportService;
+import com.mmc.bookduck.domain.user.service.UserSearchService;
 import com.mmc.bookduck.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,16 +18,16 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
-    private final UserService userService;
     private final UserGrowthService userGrowthService;
     private final UserItemService userItemService;
     private final UserReadingReportService userReadingReportService;
+    private final UserSearchService userSearchService;
 
     @Operation(summary = "유저 검색", description = "유저를 검색합니다.")
     @GetMapping("/search")
     public ResponseEntity<?> searchUsers(@RequestParam("keyword") final String keyword,
                                          @PageableDefault(size = 20) final Pageable pageable) {
-        return ResponseEntity.ok().body(userService.searchUsers(keyword, pageable));
+        return ResponseEntity.ok().body(userSearchService.searchUsers(keyword, pageable));
     }
 
     @Operation(summary = "유저 정보 조회", description = "유저의 닉네임과 기록 수를 조회합니다.")

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/common/UserUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/common/UserUnitDto.java
@@ -1,16 +1,22 @@
 package com.mmc.bookduck.domain.user.dto.common;
 
+import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
 import com.mmc.bookduck.domain.user.entity.User;
+
+import java.util.List;
 
 public record UserUnitDto(
         Long userId,
-        String nickname
-        // TODO: 캐릭터 이미지 추가해야
+        String nickname,
+        boolean isFriend,
+        List<ItemEquippedUnitDto> itemEquipped
 ) {
-    public static UserUnitDto from (User user) {
+    public static UserUnitDto from (User user, List<ItemEquippedUnitDto> itemEquipped, boolean isFriend) {
         return new UserUnitDto(
                 user.getUserId(),
-                user.getNickname()
+                user.getNickname(),
+                isFriend,
+                itemEquipped
         );
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/repository/UserRepository.java
@@ -13,7 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByNickname(String nickname);
 
-    // 유저를 닉네임으로 검색
-    @Query("SELECT u FROM User u WHERE (u.nickname LIKE %:keyword% ESCAPE '\\') AND u.userStatus = 'ACTIVE'")
-    Page<User> searchAllByNicknameContaining(@Param("keyword") String keyword, Pageable pageable);
+    // 유저를 닉네임으로 검색(시작하는)
+    @Query("SELECT u FROM User u WHERE (u.nickname LIKE :keyword% ESCAPE '\\') AND u.userStatus = 'ACTIVE'")
+    Page<User> searchAllByNicknameStartingWith(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
@@ -28,14 +28,14 @@ public class UserGrowthService {
     @Transactional(readOnly = true)
     public UserGrowth getUserGrowthByUserId(Long userId)
     {
-        User user = userService.getUserByUserId(userId);
+        User user = userService.getActiveUserByUserId(userId);
         return userGrowthRepository.findByUser(user)
                 .orElseThrow(()-> new CustomException(ErrorCode.USERGROWTH_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
     public UserInfoResponseDto getUserInfo(Long userId) {
-        User user = userService.getUserByUserId(userId);
+        User user = userService.getActiveUserByUserId(userId);
         int currentYear = Year.now().getValue();
         long reviewCount = reviewRepository.countByUserAndCreatedTimeThisYear(user, currentYear);
         long excerptCount = excerptRepository.countByUserAndCreatedTimeThisYear(user, currentYear);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserReadingReportService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserReadingReportService.java
@@ -30,7 +30,7 @@ public class UserReadingReportService {
     private final UserService userService;
 
     public UserStatisticsResponseDto getUserStatistics(Long userId) {
-        User user = userService.getUserByUserId(userId);
+        User user = userService.getActiveUserByUserId(userId);
 
         // 1. 가장 많이 읽은 카테고리, Top3 카테고리 // TODO: 카테고리? GenreName?
         List<Object[]> topCategoryResults = userBookRepository.findTopCategoriesByUser(user, Pageable.ofSize(3));

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
@@ -1,0 +1,47 @@
+package com.mmc.bookduck.domain.user.service;
+
+import com.mmc.bookduck.domain.friend.service.FriendService;
+import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
+import com.mmc.bookduck.domain.item.entity.UserItem;
+import com.mmc.bookduck.domain.item.service.UserItemService;
+import com.mmc.bookduck.domain.user.dto.common.UserUnitDto;
+import com.mmc.bookduck.domain.user.dto.response.UserSearchResponseDto;
+import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.mmc.bookduck.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserSearchService {
+    private final UserRepository userRepository;
+    private final UserItemService userItemService;
+    private final FriendService friendService;
+
+    // 유저 검색
+    public UserSearchResponseDto searchUsers(String keyword, Pageable pageable) {
+        // 키워드의 이스케이프 처리
+        String escapedWord = escapeSpecialCharacters(keyword);
+        Page<User> userPage = getSearchedUserPage(escapedWord, pageable);
+
+        Page<UserUnitDto> userUnitDtoPage = userPage.map(user -> {
+            List<ItemEquippedUnitDto> userItems = userItemService.getUserItemEquippedListOfUser(user);
+            boolean isFriend = friendService.isFriendWithCurrentUser(user);
+            return UserUnitDto.from(user, userItems, isFriend);
+        });
+        return UserSearchResponseDto.from(userUnitDtoPage);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<User> getSearchedUserPage(String keyword, Pageable pageable) {
+        return userRepository.searchAllByNicknameContaining(keyword, pageable);
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
@@ -10,7 +10,9 @@ import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +44,11 @@ public class UserSearchService {
 
     @Transactional(readOnly = true)
     public Page<User> getSearchedUserPage(String keyword, Pageable pageable) {
-        return userRepository.searchAllByNicknameContaining(keyword, pageable);
+        Pageable sortedByNickname = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by("nickname").ascending()
+        );
+        return userRepository.searchAllByNicknameStartingWith(keyword, sortedByNickname);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserService.java
@@ -43,18 +43,12 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public User getActiveUserByUserId(Long userId) throws CustomException {
-        User user = getUserByUserId(userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateActiveUserStatus(user);
         return user;
     }
-
-    @Transactional(readOnly = true)
-    public User getUserByUserId(Long userId) throws CustomException {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        return user;
-    }
-
+    
     // 사용자가 활성 상태임을 검증
     private void validateActiveUserStatus(User user) throws CustomException {
         if (!user.getUserStatus().equals(UserStatus.ACTIVE)) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserService.java
@@ -1,23 +1,15 @@
 package com.mmc.bookduck.domain.user.service;
 
-import com.mmc.bookduck.domain.user.dto.common.UserUnitDto;
-import com.mmc.bookduck.domain.user.dto.response.UserInfoResponseDto;
-import com.mmc.bookduck.domain.user.dto.response.UserSearchResponseDto;
 import com.mmc.bookduck.domain.user.entity.User;
-import com.mmc.bookduck.domain.user.entity.UserGrowth;
 import com.mmc.bookduck.domain.user.entity.UserStatus;
 import com.mmc.bookduck.domain.user.repository.UserRepository;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.mmc.bookduck.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
 
 @Service
 @RequiredArgsConstructor
@@ -59,21 +51,6 @@ public class UserService {
     @Transactional
     public User saveUser(User user){
         return userRepository.save(user);
-    }
-
-    // 유저 검색
-    public UserSearchResponseDto searchUsers(String keyword, Pageable pageable) {
-        // 키워드의 이스케이프 처리
-        String escapedWord = escapeSpecialCharacters(keyword);
-        Page<User> userPage = getSearchedUserPage(escapedWord, pageable);
-
-        Page<UserUnitDto> userUnitDtoPage = userPage.map(UserUnitDto::from);
-        return UserSearchResponseDto.from(userUnitDtoPage);
-    }
-
-    @Transactional(readOnly = true)
-    public Page<User> getSearchedUserPage(String keyword, Pageable pageable) {
-        return userRepository.searchAllByNicknameContaining(keyword, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/CustomOAuth2UserService.java
@@ -51,7 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         User user = getOrSave(oAuth2Attributes);
 
         // OAuth2UserDetails 반환
-        return new OAuth2UserDetails(oAuth2UserAttributes, userNameAttributeName, user.getEmail(), oAuth2Attributes.isNewUser(), user.getRole().name());
+        return new OAuth2UserDetails(oAuth2UserAttributes, userNameAttributeName, user.getEmail(), oAuth2Attributes.isNewUser(), user.getRole().name(), user.getUserId());
     }
 
     @Transactional

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2SuccessHandler.java
@@ -30,7 +30,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             // 액세스 토큰 유효 시간
             int expiresIn = jwtUtil.getAccessTokenMaxAge();
 
-             // 새로운 리프레시 토큰 발급
+            // 새로운 리프레시 토큰 발급
             String refreshToken = jwtUtil.generateRefreshToken(authentication);
             // 리프레시 토큰을 HttpOnly 쿠키에 저장
             cookieUtil.addCookie(response, "refreshToken", refreshToken, jwtUtil.getRefreshTokenMaxAge());
@@ -38,6 +38,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             // OAuth2UserDetails를 통해 신규 유저 여부 확인
             OAuth2UserDetails userDetails = (OAuth2UserDetails) authentication.getPrincipal();
             boolean isNewUser = userDetails.isNewUser();
+
+            // userId를 건넴
+            Long userId = userDetails.userId();
 
             // 로그 출력용
             if (isNewUser) {
@@ -51,6 +54,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     .queryParam("accessToken", accessToken)
                     .queryParam("expiresIn", expiresIn)
                     .queryParam("isNewUser", isNewUser)
+                    .queryParam("userId", userId)
                     .build()
                     .toUriString();
             response.sendRedirect(redirectUrl);

--- a/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2UserDetails.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/oauth2/OAuth2UserDetails.java
@@ -14,7 +14,8 @@ public record OAuth2UserDetails(
         String attributeKey,
         String email,
         Boolean isNewUser, // 신규 회원 여부
-        String role // 권한
+        String role, // 권한
+        Long userId // userId
 ) implements OAuth2User, UserDetails {
 
     @Override


### PR DESCRIPTION
# 구현 기능
  - 유저 검색 API에 장착 아이템과 친구 상태 반환하도록 수정
  - 로그인 시 requestParam에 userId를 추가

# Resolve
  - #16 
