### PR TITLE
[Fix] RequestParam으로 변경

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/auth/controller/AuthController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/auth/controller/AuthController.java
@@ -18,7 +18,7 @@ public class AuthController {
             description = "만료된 액세스 토큰과 만료되지 않은 리프레시 토큰을 통해 두 토큰 모두의 재발급을 요청합니다.")
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(@CookieValue("refreshToken") String refreshToken,
-                                          @RequestHeader("Authorization") String accessToken) {
+                                          @RequestParam final String accessToken) {
         // 리프레시 토큰 검증 및 액세스 토큰과 리프레시 토큰 재발급
         return ResponseEntity.ok(authService.refreshTokens(accessToken, refreshToken));
     }


### PR DESCRIPTION
# 구현 기능
  - 만료된 액세스 토큰을 헤더를 통해 보내도록 하는 것이 아니라 requestParam을 통해서 보내도록 변경했습니다.