### PR TITLE
[Fix] JwtFilter에서 Location으로 리다이렉트를 제거

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/global/security/ErrorResponseUtil.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/security/ErrorResponseUtil.java
@@ -35,10 +35,4 @@ public class ErrorResponseUtil {
             e.printStackTrace();
         }
     }
-
-    // Location 있는 에러 응답
-    public static void writeErrorResponseWithLocationHeader(HttpServletResponse response, ErrorCode errorCode, String requestUri, String locationUri) {
-        response.setHeader("Location", locationUri);
-        writeErrorResponse(response, errorCode, requestUri);
-    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/security/JwtFilter.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/security/JwtFilter.java
@@ -39,7 +39,7 @@ public class JwtFilter extends OncePerRequestFilter {
                         try {
                             // 리프레시 토큰의 유효성을 검증
                             jwtUtil.validateRefreshToken(refreshToken);
-                            ErrorResponseUtil.writeErrorResponseWithLocationHeader(response, e.getErrorCode(), request.getRequestURI(), "/auth/refresh");
+                            ErrorResponseUtil.writeErrorResponse(response, e.getErrorCode(), request.getRequestURI());
                             return;
                         } catch (CustomTokenException ex) {
                             ErrorResponseUtil.writeErrorResponse(response, ex.getErrorCode(), request.getRequestURI());


### PR DESCRIPTION
# 구현 기능
  - BE의 Location 헤더 응답으로 토큰 재발행이 2번 이루어져 제거했습니다