### PR TITLE
[HotFix] ArchiveResponseDto에 bookInfoId 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/ArchiveResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/ArchiveResponseDto.java
@@ -6,10 +6,11 @@ public record ArchiveResponseDto(
         Long archiveId,
         ExcerptResponseDto excerpt,
         ReviewResponseDto review,
+        Long bookInfoId,
         String title,
         String author
 ) {
-    public static ArchiveResponseDto from(Archive archive, ExcerptResponseDto excerpt, ReviewResponseDto review, String title, String author) {
-        return new ArchiveResponseDto(archive.getArchiveId(), excerpt, review, title, author);
+    public static ArchiveResponseDto from(Archive archive, ExcerptResponseDto excerpt, ReviewResponseDto review, Long bookInfoId, String title, String author) {
+        return new ArchiveResponseDto(archive.getArchiveId(), excerpt, review, bookInfoId, title, author);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -13,6 +13,7 @@ import com.mmc.bookduck.domain.archive.entity.Excerpt;
 import com.mmc.bookduck.domain.archive.entity.Review;
 import com.mmc.bookduck.domain.archive.repository.ArchiveRepository;
 import com.mmc.bookduck.domain.book.dto.request.UserBookRequestDto;
+import com.mmc.bookduck.domain.book.entity.BookInfo;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.service.UserBookService;
 import com.mmc.bookduck.domain.user.entity.User;
@@ -137,12 +138,14 @@ public class ArchiveService {
     }
 
     public ArchiveResponseDto createArchiveResponseDto(Archive archive, Excerpt excerpt, Review review, UserBook userBook) {
+        Long bookInfoId = userBook.getBookInfo().getBookInfoId();
         String title = userBook.getBookInfo().getTitle();
         String author = userBook.getBookInfo().getAuthor();
         return ArchiveResponseDto.from(
                 archive,
                 excerpt != null ? ExcerptResponseDto.from(excerpt) : null,
                 review != null ? ReviewResponseDto.from(review) : null,
+                bookInfoId,
                 title,
                 author
         );


### PR DESCRIPTION
# 구현 기능
  - 아래 첨부한 이미지에서 사용되는 응답인 ArchiveResponseDto에 bookInfoId 추가하여, 해당 페이지에서 책 상세페이지로 이동 가능하게 만들었습니다. 
![image](https://github.com/user-attachments/assets/4e1c37d6-3ab2-4478-b239-8ed27f6f55d8)

# 구현 상태
- 따라서 현재 응답은 다음과 같습니다.
```
 {
    "archiveId": 2,
    "excerpt": {
        "excerptId": 2,
        "excerptContent": "내용내용",
        "pageNumber": 123,
        "visibility": "PRIVATE",
        "createdTime": "2024-11-12T22:36:23.64246",
        "modifiedTime": "2024-11-12T22:51:53.923147"
    },
    "review": {
        "ReviewId": 2,
        "reviewTitle": "제목제목",
        "reviewContent": "으갸갸갸",
        "color": "#FFFFFF",
        "visibility": "PRIVATE",
        "createdTime": "2024-11-12T22:37:59.251107",
        "modifiedTime": "2024-11-12T22:51:53.924057"
    },
    "bookInfoId": 2,
    "title": "커스텀북 제목",
    "author": "김작가"
}
```

# Resolve
  - #86
