### PR TITLE
[Feat] folderBookOrder 필드 추가, 순서 수정 API

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
@@ -1,13 +1,12 @@
 package com.mmc.bookduck.domain.folder.controller;
 
+import com.mmc.bookduck.domain.folder.dto.request.FolderBookOrderRequestDto;
 import com.mmc.bookduck.domain.folder.dto.request.FolderRequestDto;
 import com.mmc.bookduck.domain.folder.dto.response.AllFolderListResponseDto;
 import com.mmc.bookduck.domain.folder.dto.response.CandidateFolderBookListResponseDto;
 import com.mmc.bookduck.domain.folder.dto.response.FolderBookListResponseDto;
 import com.mmc.bookduck.domain.folder.dto.response.FolderResponseDto;
 import com.mmc.bookduck.domain.folder.service.FolderService;
-import com.mmc.bookduck.global.exception.CustomException;
-import com.mmc.bookduck.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -102,4 +101,11 @@ public class FolderController {
                 .body((folderService.getFolderBookListStatus(folderId, status)));
     }
 
+    @Operation(summary = "폴더 책 순서 변경", description = "폴더안의 책 순서를 변경합니다.")
+    @PatchMapping("/{folderId}/books/order")
+    public ResponseEntity<FolderBookListResponseDto> updateFolderBookOrder(@PathVariable(name="folderId") final Long folderId,
+                                                                           @RequestBody final FolderBookOrderRequestDto requestDto){
+        return ResponseEntity.status(HttpStatus.OK)
+                .body((folderService.updateFolderBookOrder(folderId, requestDto)));
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookOrderUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookOrderUnitDto.java
@@ -1,0 +1,5 @@
+package com.mmc.bookduck.domain.folder.dto.common;
+
+public record FolderBookOrderUnitDto(Long folderBookId,
+                                     int order) {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
@@ -3,7 +3,7 @@ package com.mmc.bookduck.domain.folder.dto.common;
 import com.mmc.bookduck.domain.book.entity.ReadStatus;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
 
-public record FolderBookUnitDto(Long folderBookId, Long userBookId, String title, String author, String imgPath, ReadStatus readStatus) {
+public record FolderBookUnitDto(Long folderBookId, Long userBookId, String title, String author, String imgPath, ReadStatus readStatus, int folderBookOrder) {
     public static FolderBookUnitDto from(FolderBook folderBook) {
         return new FolderBookUnitDto(
                 folderBook.getFolderBookId(),
@@ -11,7 +11,8 @@ public record FolderBookUnitDto(Long folderBookId, Long userBookId, String title
                 folderBook.getUserBook().getBookInfo().getTitle(),
                 folderBook.getUserBook().getBookInfo().getAuthor(),
                 folderBook.getUserBook().getBookInfo().getImgPath(),
-                folderBook.getUserBook().getReadStatus()
+                folderBook.getUserBook().getReadStatus(),
+                folderBook.getBookOrder()
         );
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/request/FolderBookOrderRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/request/FolderBookOrderRequestDto.java
@@ -1,0 +1,7 @@
+package com.mmc.bookduck.domain.folder.dto.request;
+
+import com.mmc.bookduck.domain.folder.dto.common.FolderBookOrderUnitDto;
+import java.util.List;
+
+public record FolderBookOrderRequestDto(List<FolderBookOrderUnitDto> folderBooksOrder) {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/Folder.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/Folder.java
@@ -29,6 +29,7 @@ public class Folder {
     private User user;
 
     @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("bookOrder ASC")
     private List<FolderBook> folderBooks;
 
     @Builder

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/FolderBook.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/FolderBook.java
@@ -19,6 +19,8 @@ public class FolderBook {
     @Column(updatable = false)
     private Long folderBookId;
 
+    private int bookOrder;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "folder_id", updatable = false)
     @NotNull
@@ -34,9 +36,14 @@ public class FolderBook {
     public FolderBook(UserBook userBook, Folder folder) {
         this.folder = folder;
         this.userBook = userBook;
+        this.bookOrder = 1;
     }
 
     public void setFolder(Folder folder) {
         this.folder = folder;
+    }
+
+    public void setBookOrder(int i) {
+        this.bookOrder = i;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderBookRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderBookRepository.java
@@ -3,8 +3,11 @@ package com.mmc.bookduck.domain.folder.repository;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.folder.entity.Folder;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FolderBookRepository extends JpaRepository<FolderBook, Long> {
     boolean existsByUserBookAndFolder(UserBook userBook, Folder folder);
+
+    List<FolderBook> findByFolderOrderByBookOrderAsc(Folder folder);
 }


### PR DESCRIPTION
# 구현 기능
  - folderBook에 bookOrder 필드 추가했습니다.
  - folderBook 목록 조회에서 순서도 같이 응답하도록 수정했습니다.
  - folderBook 순서 변경하는 API 개발했습니다.
