### PR TITLE
[Fix] 토큰 재발급 시 쿠키의 값을 아예 교체

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/auth/controller/AuthController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.mmc.bookduck.domain.auth.controller;
 
 import com.mmc.bookduck.domain.auth.service.AuthService;
+import com.mmc.bookduck.global.security.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,8 +20,8 @@ public class AuthController {
             description = "만료된 액세스 토큰과 만료되지 않은 리프레시 토큰을 통해 두 토큰 모두의 재발급을 요청합니다.")
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(@CookieValue("refreshToken") String refreshToken,
-                                          @RequestParam final String accessToken) {
-        // 리프레시 토큰 검증 및 액세스 토큰과 리프레시 토큰 재발급
-        return ResponseEntity.ok(authService.refreshTokens(accessToken, refreshToken));
+                                          @RequestParam final String accessToken,
+                                          HttpServletResponse response) {
+        return ResponseEntity.ok(authService.refreshTokens(accessToken, refreshToken, response));
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/auth/dto/response/TokenResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/auth/dto/response/TokenResponseDto.java
@@ -2,8 +2,6 @@ package com.mmc.bookduck.domain.auth.dto.response;
 
 public record TokenResponseDto(
         String accessToken,
-        String refreshToken,
-        long accessTokenMaxAge,
-        long refreshTokenMaxAge
+        long accessTokenMaxAge
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/auth/service/AuthService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/auth/service/AuthService.java
@@ -3,9 +3,11 @@ package com.mmc.bookduck.domain.auth.service;
 import com.mmc.bookduck.domain.auth.dto.response.TokenResponseDto;
 import com.mmc.bookduck.global.exception.CustomTokenException;
 import com.mmc.bookduck.global.exception.ErrorCode;
+import com.mmc.bookduck.global.security.CookieUtil;
 import com.mmc.bookduck.global.security.JwtUtil;
 import com.mmc.bookduck.global.security.RedisService;
 import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,9 +21,10 @@ import java.util.Collections;
 public class AuthService {
     private final JwtUtil jwtUtil;
     private final RedisService redisService;
+    private final CookieUtil cookieUtil;
 
-    // 액세스 토큰 및 리프레시 토큰 재발급
-    public TokenResponseDto refreshTokens(String accessToken, String refreshToken) {
+    // 리프레시 토큰 검증 및 액세스 토큰과 리프레시 토큰 재발급
+    public TokenResponseDto refreshTokens(String accessToken, String refreshToken, HttpServletResponse response) {
         // 액세스 토큰 만료 여부 확인
         if (accessToken != null && accessToken.startsWith("Bearer ")) {
             accessToken = accessToken.substring(7);
@@ -42,14 +45,19 @@ public class AuthService {
             throw new CustomTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 이전 리프레시 토큰 삭제
+        // 기존 리프레시 토큰 삭제
         redisService.deleteValues(email);
 
-        // 새로운 액세스 토큰 및 리프레시 토큰 생성
+        // 새 액세스 토큰 및 리프레시 토큰 생성
         Authentication authentication = new UsernamePasswordAuthenticationToken(email, null, Collections.singletonList(new SimpleGrantedAuthority(claims.get("role").toString())));
         String newAccessToken = jwtUtil.generateAccessToken(authentication);
         String newRefreshToken = jwtUtil.generateRefreshToken(authentication); // Redis에 저장
 
-        return new TokenResponseDto(newAccessToken, newRefreshToken, jwtUtil.getAccessTokenMaxAge(), jwtUtil.getRefreshTokenMaxAge());
+        // 기존 쿠키 삭제
+        cookieUtil.deleteCookie(response, "refreshToken");
+        // 새 리프레시 토큰을 HttpOnly 쿠키에 저장
+        cookieUtil.addCookie(response, "refreshToken", newRefreshToken, jwtUtil.getRefreshTokenMaxAge());
+
+        return new TokenResponseDto(newAccessToken, jwtUtil.getAccessTokenMaxAge());
     }
 }


### PR DESCRIPTION
# 구현 기능
  - 토큰 재발급 시 리프레시 토큰이 담기는 쿠키의 값을 아예 교체합니다.