### PR TITLE
[Feat] 공지 조회 API 분리, 일반 알림 목록 조회 uri 변경

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/controller/AlarmController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/controller/AlarmController.java
@@ -27,7 +27,7 @@ public class AlarmController {
     }
 
     @Operation(summary = "일반 알림 목록 조회 및 읽음 처리", description = "일반 알림 목록을 조회하고 읽음 처리합니다.")
-    @PatchMapping
+    @PatchMapping("/common")
     public ResponseEntity<?> getRecentAlarms() {
         return ResponseEntity.ok(alarmService.getAndReadRecentAlarms());
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/controller/AlarmController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/controller/AlarmController.java
@@ -26,9 +26,15 @@ public class AlarmController {
         return ResponseEntity.ok(emitterService.subscribe());
     }
 
-    @Operation(summary = "알림 목록 조회 및 읽음 처리", description = "알림 목록을 조회하고 읽음 처리합니다.")
+    @Operation(summary = "일반 알림 목록 조회 및 읽음 처리", description = "일반 알림 목록을 조회하고 읽음 처리합니다.")
     @PatchMapping
     public ResponseEntity<?> getRecentAlarms() {
         return ResponseEntity.ok(alarmService.getAndReadRecentAlarms());
+    }
+
+    @Operation(summary = "공지 목록 조회 및 읽음 처리", description = "공지 목록을 조회하고 읽음 처리합니다.")
+    @PatchMapping("/announcements")
+    public ResponseEntity<?> getRecentAnnouncements() {
+        return ResponseEntity.ok(alarmService.getRecentAnnouncements());
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/common/AlarmUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/common/AlarmUnitDto.java
@@ -1,4 +1,4 @@
-package com.mmc.bookduck.domain.alarm.dto.response;
+package com.mmc.bookduck.domain.alarm.dto.common;
 
 
 import com.mmc.bookduck.domain.alarm.entity.Alarm;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/response/AlarmListResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/response/AlarmListResponseDto.java
@@ -1,5 +1,7 @@
 package com.mmc.bookduck.domain.alarm.dto.response;
 
+import com.mmc.bookduck.domain.alarm.dto.common.AlarmUnitDto;
+
 import java.util.List;
 
 public record AlarmListResponseDto(

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
@@ -7,13 +7,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AlarmType {
     GENERAL("", false),
-    ANNOUNCEMENT("[공지]", false),
+    ANNOUNCEMENT("[공지]", true),
     FRIEND_REQUEST("{0}님으로부터 친구요청이 도착했어요!", true),
     FRIEND_APPROVED("{0}님이 친구요청을 수락했어요.", true),
-    ONELINEHEART_ADDED("{0} 책의 한줄평에 좋아요를 눌렀어요.", false),
-    LEVEL_UP("야호! 오리가 Lv.{0}로 성장했어요.", false),
-    ITEM_UNLOCKED("축하합니다! 새 아이템을 획득했어요.", false),
-    BADGE_UNLOCKED("축하합니다! \uD83C\uDF89 새 뱃지를 획득했어요.", false),
+    ONELINELIKE_ADDED("{0}의 한줄평에 좋아요가 눌렸어요.", true),
+    LEVEL_UP("야호! 오리가 Lv.{0}로 성장했어요.", true),
+    BADGE_UNLOCKED("축하합니다! \uD83C\uDF89 새로운 {0} 뱃지를 획득했어요.", true),
     PUSH("",true), // 기타 푸시알림
     ;
 
@@ -24,7 +23,7 @@ public enum AlarmType {
     // 메시지 생성 메서드
 //    public String generateMessage(Alarm alarm) {
 //        return switch (this) {
-//            case FRIEND_REQUEST, FRIEND_APPROVED, ONELINEHEART_ADDED, BADGE_UNLOCKED ->
+//            case FRIEND_REQUEST, FRIEND_APPROVED, ONELINELIKE_ADDED, BADGE_UNLOCKED ->
 //                    MessageFormat.format(messagePattern, alarm.getSender().getNickname());
 //            case LEVEL_UP ->
 //                    MessageFormat.format(messagePattern, alarm.getResourceValue());

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
@@ -1,14 +1,21 @@
 package com.mmc.bookduck.domain.alarm.repository;
 
 import com.mmc.bookduck.domain.alarm.entity.Alarm;
+import com.mmc.bookduck.domain.alarm.entity.AlarmType;
 import com.mmc.bookduck.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
-    Slice<Alarm> findByReceiverOrderByCreatedTimeDesc(User user, Pageable pageable);
-    Boolean existsByReceiverAndIsReadFalse(User user);
+    Boolean existsByReceiverAndIsReadFalseAndNotAnnouncement(User user);
     void deleteAllBySender(User user);
     void deleteAllByReceiver(User user);
+
+    @Query("SELECT a FROM Alarm a WHERE a.receiver = :user AND a.alarmType <> 'ANNOUNCEMENT' ORDER BY a.createdTime DESC")
+    Page<Alarm> findByReceiverAndNotAnnouncementOrderByCreatedTimeDesc(@Param("user") User user, Pageable pageable);
+    Page<Alarm> findByAlarmTypeOrderByCreatedTimeDesc(@NotNull AlarmType alarmType, Pageable pageable);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
@@ -11,11 +11,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
-    Boolean existsByReceiverAndIsReadFalseAndNotAnnouncement(User user);
-    void deleteAllBySender(User user);
-    void deleteAllByReceiver(User user);
+    Boolean existsByReceiverAndIsReadFalseAndAlarmTypeNot(User receiver, AlarmType alarmType);
 
     @Query("SELECT a FROM Alarm a WHERE a.receiver = :user AND a.alarmType <> 'ANNOUNCEMENT' ORDER BY a.createdTime DESC")
     Page<Alarm> findByReceiverAndNotAnnouncementOrderByCreatedTimeDesc(@Param("user") User user, Pageable pageable);
+
     Page<Alarm> findByAlarmTypeOrderByCreatedTimeDesc(@NotNull AlarmType alarmType, Pageable pageable);
+
+    void deleteAllBySender(User user);
+    void deleteAllByReceiver(User user);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmByTypeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmByTypeService.java
@@ -31,8 +31,8 @@ public class AlarmByTypeService {
     }
 
     // 한줄평 좋아요 알림 생성
-    public void createOneLineHeartAlarm(User sender, User receiver, Long bookInfoId) {
-        AlarmType alarmType = AlarmType.ONELINEHEART_ADDED;
+    public void createOneLineLikeAlarm(User sender, User receiver, Long bookInfoId) {
+        AlarmType alarmType = AlarmType.ONELINELIKE_ADDED;
         String message = MessageFormat.format(alarmType.getMessagePattern(), sender.getNickname());
 
         Alarm alarm = Alarm.builder()
@@ -57,19 +57,6 @@ public class AlarmByTypeService {
                 .message(message)
                 .resourceName("UserGrowth")
                 .resourceValue(level.toString())
-                .build();
-        alarmService.createAlarm(alarm, receiver);
-    }
-
-    // 아이템 잠금해제 알림 생성
-    public void createItemUnlockAlarm(User receiver) {
-        AlarmType alarmType = AlarmType.ITEM_UNLOCKED;
-
-        Alarm alarm = Alarm.builder()
-                .alarmType(alarmType)
-                .receiver(receiver)
-                .message(alarmType.getMessagePattern())
-                .resourceName("Item")
                 .build();
         alarmService.createAlarm(alarm, receiver);
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
@@ -1,6 +1,7 @@
 package com.mmc.bookduck.domain.alarm.service;
 
 import com.mmc.bookduck.domain.alarm.dto.ssedata.AlarmDefaultDataDto;
+import com.mmc.bookduck.domain.alarm.entity.AlarmType;
 import com.mmc.bookduck.domain.alarm.repository.AlarmRepository;
 import com.mmc.bookduck.domain.alarm.repository.EmitterRepository;
 import com.mmc.bookduck.domain.user.entity.User;
@@ -36,7 +37,7 @@ public class EmitterService {
     }
 
     private void sendToClientIfNewAlarmExists(User user) {
-        Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalseAndNotAnnouncement(user);
+        Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalseAndAlarmTypeNot(user, AlarmType.ANNOUNCEMENT);
         if (isMissedAlarms.equals(true)) {
             sendToClient(user.getUserId(), AlarmDefaultDataDto.from(true), "new sse alarm exists");
         } else {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
@@ -36,7 +36,7 @@ public class EmitterService {
     }
 
     private void sendToClientIfNewAlarmExists(User user) {
-        Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(user);
+        Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalseAndNotAnnouncement(user);
         if (isMissedAlarms.equals(true)) {
             sendToClient(user.getUserId(), AlarmDefaultDataDto.from(true), "new sse alarm exists");
         } else {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/dto/response/OneLineRatingListResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/dto/response/OneLineRatingListResponseDto.java
@@ -4,18 +4,18 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 public record OneLineRatingListResponseDto(
-        int totalPages,
         int currentPage,
-        int PageSize,
+        int pageSize,
         long totalElements,
+        int totalPages,
         List<OneLineRatingUnitDto> oneLineRatingList
 ) {
     public static OneLineRatingListResponseDto from(Page<OneLineRatingUnitDto> oneLineRatingPage) {
         return new OneLineRatingListResponseDto(
-                oneLineRatingPage.getTotalPages(),
-                oneLineRatingPage.getNumber() + 1,
+                oneLineRatingPage.getNumber(),
                 oneLineRatingPage.getSize(),
                 oneLineRatingPage.getTotalElements(),
+                oneLineRatingPage.getTotalPages(),
                 oneLineRatingPage.getContent()
         );
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/response/UserListResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/response/UserListResponseDto.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-public record UserSearchResponseDto(
+public record UserListResponseDto(
     int currentPage,
     int pageSize,
     long totalElements,
@@ -13,8 +13,8 @@ public record UserSearchResponseDto(
     List<UserUnitDto> userList
 ) {
 
-    public static UserSearchResponseDto from(Page<UserUnitDto> userUnitDtoPage) {
-        return new UserSearchResponseDto(
+    public static UserListResponseDto from(Page<UserUnitDto> userUnitDtoPage) {
+        return new UserListResponseDto(
                 userUnitDtoPage.getNumber(),
                 userUnitDtoPage.getSize(),
                 userUnitDtoPage.getTotalElements(),

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
@@ -2,10 +2,9 @@ package com.mmc.bookduck.domain.user.service;
 
 import com.mmc.bookduck.domain.friend.service.FriendService;
 import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
-import com.mmc.bookduck.domain.item.entity.UserItem;
 import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.dto.common.UserUnitDto;
-import com.mmc.bookduck.domain.user.dto.response.UserSearchResponseDto;
+import com.mmc.bookduck.domain.user.dto.response.UserListResponseDto;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +28,7 @@ public class UserSearchService {
     private final FriendService friendService;
 
     // 유저 검색
-    public UserSearchResponseDto searchUsers(String keyword, Pageable pageable) {
+    public UserListResponseDto searchUsers(String keyword, Pageable pageable) {
         // 키워드의 이스케이프 처리
         String escapedWord = escapeSpecialCharacters(keyword);
         Page<User> userPage = getSearchedUserPage(escapedWord, pageable);
@@ -39,7 +38,7 @@ public class UserSearchService {
             boolean isFriend = friendService.isFriendWithCurrentUser(user);
             return UserUnitDto.from(user, userItems, isFriend);
         });
-        return UserSearchResponseDto.from(userUnitDtoPage);
+        return UserListResponseDto.from(userUnitDtoPage);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# 구현 기능
  - 공지 조회 API 분리, 일반 알림 목록 조회 uri 변경을 진행했습니다
  - AlarmType에 push T/F 설정을 수정, ONELINEHEART->ONELINELIKE으로 변경하였고, 아이템 알림 유형을 삭제했습니다