### PR TITLE
[Feat] 유저 기록 아카이브 조회 - 전체, 발췌만, 감상평만

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/ReviewResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/ReviewResponseDto.java
@@ -6,7 +6,7 @@ import com.mmc.bookduck.domain.common.Visibility;
 import java.time.LocalDateTime;
 
 public record ReviewResponseDto(
-        Long ReviewId,
+        Long reviewId,
         String reviewTitle,
         String reviewContent,
         String color,

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/UserArchiveResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/UserArchiveResponseDto.java
@@ -1,0 +1,29 @@
+package com.mmc.bookduck.domain.archive.dto.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record UserArchiveResponseDto(
+        int currentPage,
+        int pageSize,
+        long totalElements,
+        int totalPages,
+        List<ArchiveWithType> archiveList
+) {
+    public record ArchiveWithType(
+            String type, // EXCERPT, REVIEW
+            Object data  // ExcerptResponseDto, ReviewResponseDto
+    ) {}
+    public static UserArchiveResponseDto from(Page<ArchiveWithType> archivePage) {
+        return new UserArchiveResponseDto(
+                archivePage.getNumber(),
+                archivePage.getSize(),
+                archivePage.getTotalElements(),
+                archivePage.getTotalPages(),
+                archivePage.getContent()
+        );
+    }
+}
+
+
+

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/UserArchiveResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/UserArchiveResponseDto.java
@@ -12,7 +12,9 @@ public record UserArchiveResponseDto(
 ) {
     public record ArchiveWithType(
             String type, // EXCERPT, REVIEW
-            Object data  // ExcerptResponseDto, ReviewResponseDto
+            Object data, // ExcerptResponseDto, ReviewResponseDto
+            String title,
+            String author
     ) {}
     public static UserArchiveResponseDto from(Page<ArchiveWithType> archivePage) {
         return new UserArchiveResponseDto(

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/ArchiveType.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/ArchiveType.java
@@ -2,5 +2,6 @@ package com.mmc.bookduck.domain.archive.entity;
 
 public enum ArchiveType {
     EXCERPT,
-    REVIEW
+    REVIEW,
+    ALL
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ExcerptRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ExcerptRepository.java
@@ -34,4 +34,9 @@ public interface ExcerptRepository extends JpaRepository<Excerpt, Long> {
             @Param("keyword") String keyword,
             @Param("user") User user,
             Pageable pageable);
+
+
+    @Query("SELECT e FROM Excerpt e WHERE e.user.id = :userId")
+    List<Excerpt> findByUserId(@Param("userId") Long userId);
+
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ReviewRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ReviewRepository.java
@@ -19,4 +19,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findReviewByUserBookOrderByCreatedTimeDesc(UserBook userBook);
 
     List<Review> findAllByUserAndCreatedTimeAfter(User user, LocalDateTime createdTime);
+
+    @Query("SELECT e FROM Review e WHERE e.user.id = :userId")
+    List<Review> findByUserId(@Param("userId") Long userId);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -18,6 +18,8 @@ import com.mmc.bookduck.domain.archive.repository.ReviewRepository;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.service.UserBookService;
 import com.mmc.bookduck.domain.common.Visibility;
+import com.mmc.bookduck.domain.friend.entity.Friend;
+import com.mmc.bookduck.domain.friend.repository.FriendRepository;
 import com.mmc.bookduck.domain.user.service.UserService;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
@@ -46,6 +48,7 @@ public class ArchiveService {
     private final ArchiveRepository archiveRepository;
     private final ExcerptRepository excerptRepository;
     private final ReviewRepository reviewRepository;
+    private final FriendRepository friendRepository;
 
     // 생성
     public ArchiveResponseDto createArchive(ArchiveCreateRequestDto requestDto) {
@@ -156,6 +159,13 @@ public class ArchiveService {
     public UserArchiveResponseDto getUserArchive(Long userId, ArchiveType archiveType, Pageable pageable){
         userService.getActiveUserByUserId(userId);
         Long currentUserId = userService.getCurrentUser().getUserId();
+        // currentUserId가 userId와 다르면 친구인지 확인
+        if (!userId.equals(currentUserId)) {
+            Optional<Friend> friend = friendRepository.findFriendBetweenUsers(currentUserId, userId);
+            if (!friend.isPresent()) {
+                return new UserArchiveResponseDto(0, 0, 0, 0, new ArrayList<>());
+            }
+        }
         List<UserArchiveResponseDto.ArchiveWithType> archiveList = new ArrayList<>();
         // 발췌 조회
         if (archiveType == ArchiveType.EXCERPT || archiveType == ArchiveType.ALL) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -197,10 +197,7 @@ public class ArchiveService {
                     ((ReviewResponseDto) a2.data()).createdTime();
             return time2.compareTo(time1);
         });
-        Page<UserArchiveResponseDto.ArchiveWithType> archivePage = new PageImpl<>(archiveList, pageable, archiveList.size());
-        Page<UserArchiveResponseDto.ArchiveWithType> dtoPage = archivePage.map(item ->
-                new UserArchiveResponseDto.ArchiveWithType(item.type(), item.data())
-        );
+        Page<UserArchiveResponseDto.ArchiveWithType> dtoPage = new PageImpl<>(archiveList, pageable, archiveList.size());
         return UserArchiveResponseDto.from(dtoPage);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -163,7 +163,7 @@ public class ArchiveService {
         if (!userId.equals(currentUserId)) {
             Optional<Friend> friend = friendRepository.findFriendBetweenUsers(currentUserId, userId);
             if (!friend.isPresent()) {
-                return new UserArchiveResponseDto(0, 0, 0, 0, new ArrayList<>());
+                throw new CustomException(ErrorCode.FRIENDSHIP_REQUIRED);
             }
         }
         List<UserArchiveResponseDto.ArchiveWithType> archiveList = new ArrayList<>();

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -174,7 +174,9 @@ public class ArchiveService {
                 if (!userId.equals(currentUserId) && excerpt.getVisibility() != Visibility.PUBLIC) {
                     continue;
                 }
-                archiveList.add(new UserArchiveResponseDto.ArchiveWithType("EXCERPT", ExcerptResponseDto.from(excerpt)));
+                String title = excerpt.getUserBook().getBookInfo().getTitle();
+                String author = excerpt.getUserBook().getBookInfo().getAuthor();
+                archiveList.add(new UserArchiveResponseDto.ArchiveWithType("EXCERPT", ExcerptResponseDto.from(excerpt), title, author));
             }
         }
         // 리뷰 조회
@@ -184,7 +186,9 @@ public class ArchiveService {
                 if (!userId.equals(currentUserId) && review.getVisibility() != Visibility.PUBLIC) {
                     continue;
                 }
-                archiveList.add(new UserArchiveResponseDto.ArchiveWithType("REVIEW", ReviewResponseDto.from(review)));
+                String title = review.getUserBook().getBookInfo().getTitle();
+                String author = review.getUserBook().getBookInfo().getAuthor();
+                archiveList.add(new UserArchiveResponseDto.ArchiveWithType("REVIEW", ReviewResponseDto.from(review), title, author));
             }
         }
         // 데이터 합친 후 최신순 정렬

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/dto/common/FriendUnitDto.java
@@ -2,6 +2,7 @@ package com.mmc.bookduck.domain.friend.dto.common;
 
 import com.mmc.bookduck.domain.friend.entity.Friend;
 import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
+import com.mmc.bookduck.domain.user.entity.User;
 
 import java.util.List;
 
@@ -11,11 +12,11 @@ public record FriendUnitDto(
         String nickname,
         List<ItemEquippedUnitDto> userItemEquipped
 ) {
-    public static FriendUnitDto from(Friend friend, List<ItemEquippedUnitDto> userItemEquipped) {
+    public static FriendUnitDto from(Friend friend, User friendUser, List<ItemEquippedUnitDto> userItemEquipped) {
         return new FriendUnitDto(
                 friend.getFriendId(),
-                friend.getUser2().getUserId(),
-                friend.getUser2().getNickname(),
+                friendUser.getUserId(),
+                friendUser.getNickname(),
                 userItemEquipped
         );
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/repository/FriendRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/repository/FriendRepository.java
@@ -12,5 +12,5 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     @Query("SELECT f FROM Friend f WHERE (f.user1.userId = :senderId AND f.user2.userId = :receiverId) " +
             "OR (f.user1.userId = :receiverId AND f.user2.userId = :senderId)")
     Optional<Friend> findFriendBetweenUsers(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
-    List<Friend> findAllByUser1UserId(Long user1Id);
+    List<Friend> findAllByUser1UserIdOrUser2UserId(Long userId1, Long userId2);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
@@ -57,10 +57,13 @@ public class FriendService {
     @Transactional(readOnly = true)
     public FriendListResponseDto getFriendList() {
         User currentUser = userService.getCurrentUser();
-        List<FriendUnitDto> friendList = friendRepository.findAllByUser1UserId(currentUser.getUserId())
-                .stream()
+        List<Friend> friends = friendRepository.findAllByUser1UserIdOrUser2UserId(currentUser.getUserId(), currentUser.getUserId());
+        // 중복 제거
+        List<FriendUnitDto> friendList = friends.stream()
+                .filter(friend -> !friend.getUser1().getUserId().equals(currentUser.getUserId()))
                 .map(friend -> FriendUnitDto.from(friend, userItemService.getUserItemEquippedListOfUser(friend.getUser2())))
                 .collect(Collectors.toList());
+
         return FriendListResponseDto.from(friendList);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/service/OneLineService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/service/OneLineService.java
@@ -41,13 +41,13 @@ public class OneLineService {
 
     // 수정
     public void updateOneLine(Long oneLineId, OneLineUpdateRequestDto requestDto){
-        OneLine oneLine = ValidateOneLineCreator(oneLineId);
+        OneLine oneLine = validateOneLineCreator(oneLineId);
         oneLine.updateOneLine(requestDto.oneLineContent());
     }
 
     // 삭제
     public void deleteOneLine(Long oneLineId){
-        OneLine oneLine = ValidateOneLineCreator(oneLineId);
+        OneLine oneLine = validateOneLineCreator(oneLineId);
         oneLineRepository.delete(oneLine);
         userHomeService.deleteHomeCardsByOneLine(oneLine);
     }
@@ -59,7 +59,7 @@ public class OneLineService {
     }
 
     @Transactional(readOnly = true)
-    public OneLine ValidateOneLineCreator(Long oneLineId){
+    public OneLine validateOneLineCreator(Long oneLineId){
         OneLine oneLine = getOneLineById(oneLineId);
         User currentUser = userService.getCurrentUser();
         if(!oneLine.getUser().getUserId().equals(currentUser.getUserId())){

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.mmc.bookduck.domain.user.controller;
 
+import com.mmc.bookduck.domain.archive.dto.response.UserArchiveResponseDto;
+import com.mmc.bookduck.domain.archive.entity.ArchiveType;
+import com.mmc.bookduck.domain.archive.service.ArchiveService;
 import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.service.*;
 import com.mmc.bookduck.domain.userhome.service.UserReadingSpaceService;
@@ -21,6 +24,7 @@ public class UserController {
     private final UserSearchService userSearchService;
     private final UserReadingReportService userReadingReportService;
     private final UserReadingSpaceService userReadingSpaceService;
+    private final ArchiveService archiveService;
 
     @Operation(summary = "유저 검색", description = "유저를 검색합니다.")
     @GetMapping("/search")
@@ -64,5 +68,13 @@ public class UserController {
     @GetMapping("/{userId}/readingspace")
     public ResponseEntity<?> getUserReadingSpace(@PathVariable final Long userId) {
         return ResponseEntity.ok().body(userReadingSpaceService.getUserReadingSpace(userId));
+    }
+
+    @Operation(summary = "유저 기록 아카이브 조회", description = "유저의 기록 아카이브를 조회합니다.")
+    @GetMapping("{userId}/archives")
+    public ResponseEntity<?> getUserArchive(@PathVariable("userId") final Long userId, @RequestParam("type") final ArchiveType archiveType,
+                                            Pageable pageable){
+        UserArchiveResponseDto responseDto = archiveService.getUserArchive(userId, archiveType, pageable);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -29,8 +29,6 @@ public enum ErrorCode {
     // 401 Unauthorized
     // 로그인 상태여야 하는 요청
     NOT_AUTHENTICATED(401, "로그인 상태가 아닙니다."),
-    // 권한이 없는 요청을 보냄
-    UNAUTHORIZED_REQUEST(401,"권한이 없습니다."),
     // 소셜 로그인이 정상적으로 이루어지지 않음
     OAUTH2_LOGIN_FAILED(401, "소셜 로그인에 실패했습니다."),
     // 유효하지 않은 토큰
@@ -44,6 +42,11 @@ public enum ErrorCode {
     // 쿠키에 리프레시 토큰이 들어있지 않은 경우
     NO_COOKIE(401, "쿠키에 리프레시 토큰이 존재하지 않습니다."),
     USER_STATUS_IS_NOT_ACTIVE(401, "계정이 활성 상태가 아닙니다."),
+
+    // 403 Forbidden
+    FRIENDSHIP_REQUIRED(403, "친구 관계가 필요합니다."),
+    // 권한이 없는 요청을 보냄
+    UNAUTHORIZED_REQUEST(403,"권한이 없습니다."),
 
     // 404 Not Found
     // 각 리소스를 찾지 못함


### PR DESCRIPTION
# 구현 기능
  - 유저 기록 아카이브 조회 (전체, 발췌만, 감상평만 조회하기) 기능을 개발했습니다.
  -  userId를 바탕으로 기록 아카이브를 조회합니다.
  - 현재 로그인된 유저의 id와 비교하여, 
    - 친구가 아니면 볼 수 없음.
    - 친구의 기록은 visibility.PUBLIC 만 보임.
    - 내 기록은 전부 보임.
  - 페이지네이션 적용했습니다.
  - 목록은 createdTimeDESC (최신순정렬)입니다.
 
  - 친구 목록 조회 시 양방향으로 조회되도록 수정하였습니다. 
 
# Resolve
  - #86
  - #31
