### PR TITLE
[Fix] 여러status 동시 조회 / 여러 책 생성,삭제

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
@@ -190,15 +190,7 @@ public class UserBookService {
         if(statusList.isEmpty()){
             throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
         }
-
-        List<ReadStatus> readStatusList = new ArrayList<>();
-        try {
-            for(String status : statusList){
-                readStatusList.add(ReadStatus.valueOf(status));
-            }
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
-        }
+        List<ReadStatus> readStatusList = validateReadStatus(statusList);
 
         User user = userService.getCurrentUser();
         List<UserBook> sorteduserBookList = sortUserBook(user, sort);
@@ -404,5 +396,17 @@ public class UserBookService {
         if(!userBook.getUser().getUserId().equals(currentUser.getUserId())){
             throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
         }
+    }
+
+    public List<ReadStatus> validateReadStatus(List<String> statusList){
+        List<ReadStatus> readStatusList = new ArrayList<>();
+        try {
+            for(String status : statusList){
+                readStatusList.add(ReadStatus.valueOf(status));
+            }
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+        return readStatusList;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
@@ -49,12 +49,12 @@ public class FolderController {
     }
 
 
-    @Operation(summary = "폴더에 책 추가", description = "폴더에 책을 추가합니다.")
-    @PostMapping("/{folderId}/books/{userbookId}")
-    public ResponseEntity<FolderBookListResponseDto> addFolderBook(@PathVariable(name="folderId") final Long folderId,
-                                                                   @PathVariable(name="userbookId") final Long userBookId){
+    @Operation(summary = "폴더에 책 여러 개 추가", description = "폴더에 여러 개의 책을 추가합니다.")
+    @PostMapping("/{folderId}/books")
+    public ResponseEntity<FolderBookListResponseDto> addFolderBooks(@PathVariable(name="folderId") final Long folderId,
+                                                                    @RequestBody List<Long> userBookIds){
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(folderService.addFolderBook(folderId, userBookId));
+                .body(folderService.addFolderBooks(folderId, userBookIds));
     }
 
 
@@ -68,12 +68,12 @@ public class FolderController {
     }
 
 
-    @Operation(summary = "폴더에서 책 삭제", description = "폴더에서 책을 삭제합니다.")
-    @DeleteMapping("/{folderId}/books/{folderbookId}")
-    public ResponseEntity<FolderBookListResponseDto> deleteFolderBook(@PathVariable(name="folderId") final Long folderId,
-                                                                      @PathVariable(name="folderbookId") final Long folderBookId){
+    @Operation(summary = "폴더에서 책 여러 개 삭제", description = "폴더에서 여러 개의 책을 삭제합니다.")
+    @DeleteMapping("/{folderId}/books")
+    public ResponseEntity<FolderBookListResponseDto> deleteFolderBooks(@PathVariable(name="folderId") final Long folderId,
+                                                                       @RequestBody List<Long> folderBookIds){
         return ResponseEntity.status(HttpStatus.OK)
-                .body(folderService.deleteFolderBook(folderId, folderBookId));
+                .body(folderService.deleteFolderBooks(folderId, folderBookIds));
     }
 
     @Operation(summary = "전체 폴더 목록 조회", description = "현재 사용자의 전체 폴더 목록을 조회합니다.")

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/controller/FolderController.java
@@ -10,6 +10,7 @@ import com.mmc.bookduck.domain.folder.service.FolderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,10 +60,11 @@ public class FolderController {
 
     @Operation(summary = "폴더에 추가할 책 목록 조회", description = "폴더에 추가할 수 있는 서재 책 목록을 조회합니다.")
     @GetMapping("/{folderId}/books/candidates")
-    public ResponseEntity<CandidateFolderBookListResponseDto> getCandidateBooks(@PathVariable(name="folderId") final Long folderId){
+    public ResponseEntity<CandidateFolderBookListResponseDto> getCandidateBooks(@PathVariable(name="folderId") final Long folderId,
+                                                                                @RequestParam(name = "status", required = false) final List<String> statusList){
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(folderService.getCandidateBooks(folderId));
+                .body(folderService.getCandidateBooks(folderId, statusList));
     }
 
 
@@ -95,10 +97,10 @@ public class FolderController {
     @Operation(summary = "폴더별&상태별 책 목록 조회", description = "폴더에 포함된 책에서 특정 상태의 책 목록을 조회합니다.")
     @GetMapping("/{folderId}/books/filter")
     public ResponseEntity<FolderBookListResponseDto> getFolderBookListStatus(@PathVariable(name="folderId") final Long folderId,
-                                                                             @RequestParam(name="status") final String status){
+                                                                             @RequestParam(name = "status") final List<String> statusList){
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body((folderService.getFolderBookListStatus(folderId, status)));
+                .body((folderService.getFolderBookListStatus(folderId, statusList)));
     }
 
     @Operation(summary = "폴더 책 순서 변경", description = "폴더안의 책 순서를 변경합니다.")

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/CandidateFolderBookDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/CandidateFolderBookDto.java
@@ -8,6 +8,7 @@ public record CandidateFolderBookDto(
         String title,
         String author,
         String imgPath,
+        double rating,
         ReadStatus readStatus
 ) {
     public static CandidateFolderBookDto from(UserBook userBook) {
@@ -16,6 +17,7 @@ public record CandidateFolderBookDto(
                 userBook.getBookInfo().getTitle(),
                 userBook.getBookInfo().getAuthor(),
                 userBook.getBookInfo().getImgPath(),
+                userBook.getRating(),
                 userBook.getReadStatus()
         );
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/dto/common/FolderBookUnitDto.java
@@ -3,7 +3,7 @@ package com.mmc.bookduck.domain.folder.dto.common;
 import com.mmc.bookduck.domain.book.entity.ReadStatus;
 import com.mmc.bookduck.domain.folder.entity.FolderBook;
 
-public record FolderBookUnitDto(Long folderBookId, Long userBookId, String title, String author, String imgPath, ReadStatus readStatus, int folderBookOrder) {
+public record FolderBookUnitDto(Long folderBookId, Long userBookId, String title, String author, String imgPath, double rating, ReadStatus readStatus, int folderBookOrder) {
     public static FolderBookUnitDto from(FolderBook folderBook) {
         return new FolderBookUnitDto(
                 folderBook.getFolderBookId(),
@@ -11,6 +11,7 @@ public record FolderBookUnitDto(Long folderBookId, Long userBookId, String title
                 folderBook.getUserBook().getBookInfo().getTitle(),
                 folderBook.getUserBook().getBookInfo().getAuthor(),
                 folderBook.getUserBook().getBookInfo().getImgPath(),
+                folderBook.getUserBook().getRating(),
                 folderBook.getUserBook().getReadStatus(),
                 folderBook.getBookOrder()
         );

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/FolderBook.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/entity/FolderBook.java
@@ -33,10 +33,10 @@ public class FolderBook {
     private UserBook userBook;
 
     @Builder
-    public FolderBook(UserBook userBook, Folder folder) {
+    public FolderBook(UserBook userBook, Folder folder, int bookOrder) {
         this.folder = folder;
         this.userBook = userBook;
-        this.bookOrder = 1;
+        this.bookOrder = bookOrder;
     }
 
     public void setFolder(Folder folder) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderBookService.java
@@ -8,6 +8,7 @@ import com.mmc.bookduck.domain.folder.entity.FolderBook;
 import com.mmc.bookduck.domain.folder.repository.FolderBookRepository;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +24,17 @@ public class FolderBookService {
     private final FolderBookRepository folderBookRepository;
 
     // folderBook 생성
-    public FolderBook createFolderBook(UserBook userBook, Folder folder){
-        FolderBook folderBook = new FolderBook(userBook, folder);
-        return folderBookRepository.save(folderBook);
+    public List<FolderBook> createFolderBooks(List<UserBook> userBooks, Folder folder){
+        List<FolderBook> folderBookList = new ArrayList<>();
+
+        int i = 1;
+        for(UserBook userBook : userBooks){
+            FolderBook folderBook = new FolderBook(userBook, folder, i);
+            i++;
+
+            folderBookList.add(folderBookRepository.save(folderBook));
+        }
+        return folderBookList;
     }
 
     // 폴더삭제 시 folderBook 모두 삭제
@@ -50,9 +59,9 @@ public class FolderBookService {
     }
 
     @Transactional
-    public void incrementOrderFolderBooks(Folder folder){
+    public void incrementOrderFolderBooks(Folder folder, int size){
         List<FolderBook> existingBooks = folder.getFolderBooks();
-        existingBooks.forEach(fb -> fb.setBookOrder(fb.getBookOrder()+1));
+        existingBooks.forEach(fb -> fb.setBookOrder(fb.getBookOrder()+size));
     }
 
     @Transactional


### PR DESCRIPTION
# 구현 기능
  - folderBook 목록을 조회할 때, 여러 status 동시에 선택해서 조회할 수 있도록 했습니다
  - folderBook 목록에서 별점도 같이 응답으로 보내는 것으로 수정했습니다.
  - folderBook 생성과 삭제 기능을 여러 책을 한번에 처리하도록 수정했습니다.
  

# Resolve
- #113