### PR TITLE
[Fix] providerId로 서재책 추가 & 상세-기본정보 조회에 author 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
@@ -5,12 +5,13 @@ import com.mmc.bookduck.domain.book.dto.common.BookCoverImageUnitDto;
 import com.mmc.bookduck.domain.book.dto.request.AddUserBookRequestDto;
 import com.mmc.bookduck.domain.book.dto.request.CustomBookUpdateDto;
 import com.mmc.bookduck.domain.book.dto.response.AddUserBookResponseDto;
+import com.mmc.bookduck.domain.book.dto.response.BookUnitResponseDto;
 import com.mmc.bookduck.domain.book.dto.response.CustomBookResponseDto;
 import com.mmc.bookduck.domain.book.dto.common.CustomBookUnitDto;
 import com.mmc.bookduck.domain.book.dto.response.BookInfoAdditionalResponseDto;
 import com.mmc.bookduck.domain.book.dto.response.BookInfoBasicResponseDto;
 import com.mmc.bookduck.domain.book.dto.response.BookListResponseDto;
-import com.mmc.bookduck.domain.book.dto.response.BookUnitResponseDto;
+import com.mmc.bookduck.domain.book.dto.common.BookUnitDto;
 import com.mmc.bookduck.domain.book.service.BookInfoService;
 import com.mmc.bookduck.domain.oneline.dto.response.OneLineRatingListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,8 +35,8 @@ public class BookInfoController {
     @Operation(summary = "API 도서 목록 검색", description = "구글 API에서 특정 키워드에 해당하는 도서 목록을 검색합니다.")
     @GetMapping("/search")
     public ResponseEntity<BookListResponseDto<BookUnitResponseDto>> searchBookList(@RequestParam(name = "keyword") final String keyword,
-                                                                                   @RequestParam final Long page,
-                                                                                   @RequestParam final Long size){
+                                                                                       @RequestParam final Long page,
+                                                                                       @RequestParam final Long size){
 
         return ResponseEntity.ok(bookInfoService.searchBookList(keyword, page, size));
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
@@ -2,7 +2,9 @@ package com.mmc.bookduck.domain.book.controller;
 
 import com.mmc.bookduck.domain.archive.dto.response.UserArchiveResponseDto;
 import com.mmc.bookduck.domain.book.dto.common.BookCoverImageUnitDto;
+import com.mmc.bookduck.domain.book.dto.request.AddUserBookRequestDto;
 import com.mmc.bookduck.domain.book.dto.request.CustomBookUpdateDto;
+import com.mmc.bookduck.domain.book.dto.response.AddUserBookResponseDto;
 import com.mmc.bookduck.domain.book.dto.response.CustomBookResponseDto;
 import com.mmc.bookduck.domain.book.dto.common.CustomBookUnitDto;
 import com.mmc.bookduck.domain.book.dto.response.BookInfoAdditionalResponseDto;
@@ -13,6 +15,7 @@ import com.mmc.bookduck.domain.book.service.BookInfoService;
 import com.mmc.bookduck.domain.oneline.dto.response.OneLineRatingListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -48,6 +51,13 @@ public class BookInfoController {
     @GetMapping("/external/{providerId}")
     public ResponseEntity<BookInfoBasicResponseDto> getApiBookBasicByProviderId(@PathVariable(name = "providerId") final String providerId){
         return ResponseEntity.ok(bookInfoService.getApiBookBasicByProviderId(providerId));
+    }
+
+    @Operation(summary = "검색 목록에서 서재에 책 추가", description = "책 검색 목록에서 providerId로 책을 서재에 추가합니다.")
+    @PostMapping("/{providerId}/add")
+    public ResponseEntity<AddUserBookResponseDto> addBookByProviderId(@PathVariable(name = "providerId") final String providerId,
+                                                                      @Valid @RequestBody final AddUserBookRequestDto requestDto){
+        return ResponseEntity.ok(bookInfoService.addBookByProviderId(providerId, requestDto));
     }
 
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
@@ -116,11 +116,10 @@ public class BookInfoController {
 
     //친구의 기록과 발췌 통합 조회
     @Operation(summary = "친구의 전체 기록 조회", description = "책의 친구의 기록을 조회합니다.(감상평+발췌)")
-    @GetMapping("/{bookinfoId}/archives/users/{userId}")
-    public ResponseEntity<UserArchiveResponseDto> getAllUserBookArchive(@PathVariable(name = "bookinfoId") final Long bookInfoId,
-                                                                        @PathVariable(name = "userId") final Long userId,
+    @GetMapping("/{userbookId}/archives/users/friend")
+    public ResponseEntity<UserArchiveResponseDto> getAllUserBookArchive(@PathVariable(name = "userbookId") final Long userbookId,
                                                                         @PageableDefault(size = 20) final Pageable pageable){
         return ResponseEntity.status(HttpStatus.OK)
-                .body(bookInfoService.getAllUserBookArchive(bookInfoId, userId, pageable));
+                .body(bookInfoService.getAllUserBookArchive(userbookId, pageable));
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/BookInfoController.java
@@ -116,10 +116,11 @@ public class BookInfoController {
 
     //친구의 기록과 발췌 통합 조회
     @Operation(summary = "친구의 전체 기록 조회", description = "책의 친구의 기록을 조회합니다.(감상평+발췌)")
-    @GetMapping("/{userbookId}/archives/users/friend")
-    public ResponseEntity<UserArchiveResponseDto> getAllUserBookArchive(@PathVariable(name = "userbookId") final Long userbookId,
+    @GetMapping("/{bookinfoId}/archives/users/{userId}")
+    public ResponseEntity<UserArchiveResponseDto> getAllUserBookArchive(@PathVariable(name = "bookinfoId") final Long bookinfoId,
+                                                                        @PathVariable(name = "userId") final Long userId,
                                                                         @PageableDefault(size = 20) final Pageable pageable){
         return ResponseEntity.status(HttpStatus.OK)
-                .body(bookInfoService.getAllUserBookArchive(userbookId, pageable));
+                .body(bookInfoService.getAllUserBookArchive(bookinfoId,userId, pageable));
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/UserBookController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/controller/UserBookController.java
@@ -73,6 +73,7 @@ public class UserBookController {
     }
 
 
+    /*
     @Operation(summary = "서재 책 상세-기본 정보 조회", description = "사용자의 서재 책의 기본 정보를 상세 조회합니다.(책 기본정보 + 현재 사용자의 별점&한줄평)")
     @GetMapping("/{userbookId}")
     public ResponseEntity<BookInfoBasicResponseDto> getUserBookInfoBasic(@PathVariable(name = "userbookId") final Long userbookId){
@@ -89,6 +90,7 @@ public class UserBookController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(userBookService.getUserBookInfoAdditional(userbookId));
     }
+    */
 
 
     @Operation(summary = "책 직접 등록", description = "사용자가 책을 직접 등록합니다.")

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/BookInfoDetailDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/BookInfoDetailDto.java
@@ -1,6 +1,8 @@
 package com.mmc.bookduck.domain.book.dto.common;
 
+import com.mmc.bookduck.domain.book.dto.request.AddUserBookRequestDto;
 import com.mmc.bookduck.domain.book.entity.BookInfo;
+import com.mmc.bookduck.domain.book.entity.Genre;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 
 import java.util.List;
@@ -27,5 +29,21 @@ public record BookInfoDetailDto(
                 koreanGenreName,
                 bookInfo.getLanguage()
         );
+    }
+
+    public BookInfo toEntity(String providerId, AddUserBookRequestDto dto, Genre genre) {
+        return BookInfo.builder()
+                .providerId(providerId)
+                .title(dto.title())
+                .author(dto.authors().getFirst())
+                .publisher(this.publisher)
+                .publishDate(this.publishedDate)
+                .description(this.description)
+                .category(this.category != null && !this.category.isEmpty() ? this.category.get(0) : null)
+                .genre(genre)
+                .pageCount(this.pageCount)
+                .imgPath(dto.imgPath())
+                .language(this.language)
+                .build();
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/BookUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/BookUnitDto.java
@@ -1,0 +1,52 @@
+package com.mmc.bookduck.domain.book.dto.common;
+
+import com.mmc.bookduck.domain.book.entity.BookInfo;
+import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import jakarta.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.List;
+
+public record BookUnitDto(
+        Long bookInfoId,
+        Long userbookId,
+        @NotNull String title,
+        List<String> author,
+        String imgPath,
+        Double myRating,
+        ReadStatus readStatus
+) {
+    public static BookUnitDto from(BookUnitParseDto infoDto, MyRatingOneLineReadStatusDto ratingDto, Long bookInfoId){
+        return new BookUnitDto(
+                bookInfoId,
+                ratingDto.userbookId(),
+                infoDto.title(),
+                infoDto.author(),
+                infoDto.imgPath(),
+                ratingDto.myRating(),
+                ratingDto.readStatus()
+        );
+    }
+    public static BookUnitDto from(BookUnitParseDto infoDto){
+        return new BookUnitDto(
+                null,
+                null,
+                infoDto.title(),
+                infoDto.author(),
+                infoDto.imgPath(),
+                0.0,
+                null
+        );
+    }
+    public static BookUnitDto from(BookInfo bookInfo, MyRatingOneLineReadStatusDto ratingDto){
+        return new BookUnitDto(
+                bookInfo.getBookInfoId(),
+                ratingDto.userbookId(),
+                bookInfo.getTitle(),
+                Collections.singletonList(bookInfo.getAuthor()),
+                bookInfo.getImgPath(),
+                ratingDto.myRating(),
+                ratingDto.readStatus()
+        );
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/CustomBookUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/CustomBookUnitDto.java
@@ -6,7 +6,8 @@ import jakarta.validation.constraints.NotNull;
 
 
 public record CustomBookUnitDto(
-        Long bookinfoId,
+        Long bookInfoId,
+        Long userbookId,
         @NotNull String title,
         String author,
         String imgPath,
@@ -16,6 +17,7 @@ public record CustomBookUnitDto(
     public static CustomBookUnitDto from(BookInfo bookInfo, MyRatingOneLineReadStatusDto dto){
         return new CustomBookUnitDto(
                 bookInfo.getBookInfoId(),
+                dto.userbookId(),
                 bookInfo.getTitle(),
                 bookInfo.getAuthor(),
                 bookInfo.getImgPath(),

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/MyRatingOneLineReadStatusDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/MyRatingOneLineReadStatusDto.java
@@ -1,6 +1,31 @@
 package com.mmc.bookduck.domain.book.dto.common;
 
 import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import lombok.NoArgsConstructor;
 
-public record MyRatingOneLineReadStatusDto(Double myRating, String myOneLine, ReadStatus readStatus) {
+
+public record MyRatingOneLineReadStatusDto(Long userbookId, Double myRating, String myOneLine, ReadStatus readStatus) {
+
+    public static MyRatingOneLineReadStatusDto defaultInstance() {
+        return new MyRatingOneLineReadStatusDto(null, null, null, null);
+    }
+
+    public static MyRatingOneLineReadStatusDto from(UserBook userBook){
+        return new MyRatingOneLineReadStatusDto(
+                userBook.getUserBookId(),
+                userBook.getRating(),
+                null,
+                userBook.getReadStatus()
+        );
+    }
+
+    public static MyRatingOneLineReadStatusDto from(UserBook userBook, String oneLine){
+        return new MyRatingOneLineReadStatusDto(
+                userBook.getUserBookId(),
+                userBook.getRating(),
+                oneLine,
+                userBook.getReadStatus()
+        );
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/MyRatingOneLineReadStatusDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/common/MyRatingOneLineReadStatusDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 public record MyRatingOneLineReadStatusDto(Long userbookId, Double myRating, String myOneLine, ReadStatus readStatus) {
 
     public static MyRatingOneLineReadStatusDto defaultInstance() {
-        return new MyRatingOneLineReadStatusDto(null, null, null, null);
+        return new MyRatingOneLineReadStatusDto(null, 0.0, null, null);
     }
 
     public static MyRatingOneLineReadStatusDto from(UserBook userBook){

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/request/AddUserBookRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/request/AddUserBookRequestDto.java
@@ -1,0 +1,26 @@
+package com.mmc.bookduck.domain.book.dto.request;
+
+import com.mmc.bookduck.domain.book.entity.BookInfo;
+import com.mmc.bookduck.domain.book.entity.Genre;
+import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record AddUserBookRequestDto(
+        @NotBlank(message = "title은 필수입니다. title은 공백일 수 없습니다.") String title,
+        @NotEmpty(message = "authors은 필수입니다. authors은 최소 한 개 이상의 요소를 포함해야 합니다.") List<String> authors,
+        @NotBlank(message = "readStatus는 필수입니다.") String readStatus,
+        String imgPath
+) {
+
+    public UserBook toEntity(User user, BookInfo bookInfo, ReadStatus readStatus) {
+        return UserBook.builder()
+                .readStatus(readStatus)
+                .user(user)
+                .bookInfo(bookInfo)
+                .build();
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/AddUserBookResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/AddUserBookResponseDto.java
@@ -1,0 +1,15 @@
+package com.mmc.bookduck.domain.book.dto.response;
+
+import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.entity.UserBook;
+
+public record AddUserBookResponseDto(Long bookInfoId, Long userBookId, ReadStatus readStatus
+){
+    public static AddUserBookResponseDto from(UserBook userBook){
+        return new AddUserBookResponseDto(
+                userBook.getBookInfo().getBookInfoId(),
+                userBook.getUserBookId(),
+                userBook.getReadStatus()
+        );
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/BookInfoBasicResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/BookInfoBasicResponseDto.java
@@ -1,37 +1,26 @@
 package com.mmc.bookduck.domain.book.dto.response;
 
 import com.mmc.bookduck.domain.book.dto.common.BookInfoDetailDto;
-import com.mmc.bookduck.domain.book.entity.BookInfo;
-import com.mmc.bookduck.domain.book.entity.ReadStatus;
-import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.book.dto.common.BookUnitDto;
 
 public record BookInfoBasicResponseDto(
-        Long bookInfoId,
-        Long userbookId,
+        BookUnitDto bookInfoBasicDto,
         Double ratingAverage,
         String myOneLine,
-        Double myRating,
-        ReadStatus readStatus,
         BookInfoDetailDto bookInfoDetailDto
 ) {
-    public static BookInfoBasicResponseDto from(UserBook userBook, Double ratingAverage, String myOneLine, BookInfoDetailDto dto){
+    public static BookInfoBasicResponseDto from(BookUnitDto basicDto, Double ratingAverage, String myOneLine, BookInfoDetailDto dto){
         return new BookInfoBasicResponseDto(
-                userBook.getBookInfo().getBookInfoId(),
-                userBook.getUserBookId(),
+                basicDto,
                 ratingAverage,
                 myOneLine,
-                userBook.getRating(),
-                userBook.getReadStatus(),
                 dto
         );
     }
-    public static BookInfoBasicResponseDto from(BookInfo bookInfo, Double ratingAverage, BookInfoDetailDto dto){
+    public static BookInfoBasicResponseDto from(BookUnitDto basicDto, Double ratingAverage, BookInfoDetailDto dto){
         return new BookInfoBasicResponseDto(
-                bookInfo.getBookInfoId(),
-                null,
+                basicDto,
                 ratingAverage,
-                null,
-                null,
                 null,
                 dto
         );

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/BookUnitResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/BookUnitResponseDto.java
@@ -1,43 +1,22 @@
 package com.mmc.bookduck.domain.book.dto.response;
 
+import com.mmc.bookduck.domain.book.dto.common.BookUnitDto;
 import com.mmc.bookduck.domain.book.dto.common.BookUnitParseDto;
 import com.mmc.bookduck.domain.book.dto.common.MyRatingOneLineReadStatusDto;
-import com.mmc.bookduck.domain.book.entity.ReadStatus;
-import jakarta.validation.constraints.NotNull;
-import java.util.List;
-
-public record BookUnitResponseDto(
+public record BookUnitResponseDto (
         String providerId,
-        Long bookInfoId,
-        Long userbookId,
-        @NotNull String title,
-        List<String> author,
-        String imgPath,
-        Double myRating,
-        ReadStatus readStatus
-) {
+        BookUnitDto bookUnitDto
+){
     public static BookUnitResponseDto from(BookUnitParseDto infoDto, MyRatingOneLineReadStatusDto ratingDto, Long bookInfoId){
         return new BookUnitResponseDto(
                 infoDto.providerId(),
-                bookInfoId,
-                ratingDto.userbookId(),
-                infoDto.title(),
-                infoDto.author(),
-                infoDto.imgPath(),
-                ratingDto.myRating(),
-                ratingDto.readStatus()
+                BookUnitDto.from(infoDto, ratingDto, bookInfoId)
         );
     }
     public static BookUnitResponseDto from(BookUnitParseDto infoDto){
         return new BookUnitResponseDto(
                 infoDto.providerId(),
-                null,
-                null,
-                infoDto.title(),
-                infoDto.author(),
-                infoDto.imgPath(),
-                0.0,
-                null
+                BookUnitDto.from(infoDto)
         );
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/BookUnitResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/dto/response/BookUnitResponseDto.java
@@ -9,6 +9,7 @@ import java.util.List;
 public record BookUnitResponseDto(
         String providerId,
         Long bookInfoId,
+        Long userbookId,
         @NotNull String title,
         List<String> author,
         String imgPath,
@@ -19,6 +20,7 @@ public record BookUnitResponseDto(
         return new BookUnitResponseDto(
                 infoDto.providerId(),
                 bookInfoId,
+                ratingDto.userbookId(),
                 infoDto.title(),
                 infoDto.author(),
                 infoDto.imgPath(),
@@ -29,6 +31,7 @@ public record BookUnitResponseDto(
     public static BookUnitResponseDto from(BookUnitParseDto infoDto){
         return new BookUnitResponseDto(
                 infoDto.providerId(),
+                null,
                 null,
                 infoDto.title(),
                 infoDto.author(),

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
@@ -507,14 +507,14 @@ public class BookInfoService {
     }
 
     @Transactional(readOnly = true)
-    public UserArchiveResponseDto getAllUserBookArchive(Long bookInfoId, Long userId, Pageable pageable) {
-        User bookUser = userService.getActiveUserByUserId(userId);
+    public UserArchiveResponseDto getAllUserBookArchive(Long userbookId, Pageable pageable) {
+        UserBook userBook = userBookRepository.findById(userbookId)
+                .orElseThrow(()-> new CustomException(ErrorCode.USERBOOK_NOT_FOUND));
 
+        User bookUser = userBook.getUser();
         if(!friendService.isFriendWithCurrentUser(bookUser)){
             throw new CustomException(ErrorCode.FRIENDSHIP_REQUIRED);
         }
-        BookInfo bookInfo = getBookInfoById(bookInfoId);
-        UserBook userBook  = getUserBookByUserAndBookInfo(bookInfo, bookUser);
 
         List<UserArchiveResponseDto.ArchiveWithoutTitleAuthor> archiveList = new ArrayList<>();
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
@@ -507,14 +507,14 @@ public class BookInfoService {
     }
 
     @Transactional(readOnly = true)
-    public UserArchiveResponseDto getAllUserBookArchive(Long userbookId, Pageable pageable) {
-        UserBook userBook = userBookRepository.findById(userbookId)
-                .orElseThrow(()-> new CustomException(ErrorCode.USERBOOK_NOT_FOUND));
+    public UserArchiveResponseDto getAllUserBookArchive(Long bookInfoId, Long userId, Pageable pageable) {
+        User bookUser = userService.getActiveUserByUserId(userId);
 
-        User bookUser = userBook.getUser();
         if(!friendService.isFriendWithCurrentUser(bookUser)){
             throw new CustomException(ErrorCode.FRIENDSHIP_REQUIRED);
         }
+        BookInfo bookInfo = getBookInfoById(bookInfoId);
+        UserBook userBook = getUserBookByUserAndBookInfo(bookInfo, bookUser);
 
         List<UserArchiveResponseDto.ArchiveWithoutTitleAuthor> archiveList = new ArrayList<>();
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
@@ -10,6 +10,7 @@ import com.mmc.bookduck.domain.archive.repository.ReviewRepository;
 import com.mmc.bookduck.domain.book.dto.common.BookCoverImageUnitDto;
 import com.mmc.bookduck.domain.book.dto.common.BookInfoDetailDto;
 import com.mmc.bookduck.domain.book.dto.common.BookRatingUnitDto;
+import com.mmc.bookduck.domain.book.dto.common.BookUnitDto;
 import com.mmc.bookduck.domain.book.dto.request.CustomBookRequestDto;
 import com.mmc.bookduck.domain.book.dto.request.RatingRequestDto;
 import com.mmc.bookduck.domain.book.dto.request.UserBookRequestDto;
@@ -207,6 +208,7 @@ public class UserBookService {
     }
 
 
+    /*
     // 서재책 상세보기 - 기본정보
     @Transactional(readOnly = true)
     public BookInfoBasicResponseDto getUserBookInfoBasic(Long userBookId) {
@@ -220,14 +222,18 @@ public class UserBookService {
         Double ratingAverage = bookInfoService.getRatingAverage(userBook.getBookInfo());
 
         if(oneLine != null){
+            BookUnitDto unitDto = BookUnitDto.from(userBook);
             return BookInfoBasicResponseDto.from(userBook, ratingAverage, oneLine.getOneLineContent(), detailDto);
         }
         else{
+            BookUnitDto unitDto = BookUnitDto.from(userBook);
             return BookInfoBasicResponseDto.from(userBook, ratingAverage, null, detailDto);
         }
     }
+    */
 
 
+    /*
     // 서재 책 상세보기 - 추가정보
     @Transactional(readOnly = true)
     public BookInfoAdditionalResponseDto getUserBookInfoAdditional(Long userBookId) {
@@ -251,6 +257,7 @@ public class UserBookService {
         }
         return new BookInfoAdditionalResponseDto(oneLineList);
     }
+    */
 
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# 구현 기능
  - 책 검색 목록에서 바로 서재추가, 상태변경이 가능한데 
    현재 서재 추가 API에서 requestBody로 필요한 정보를 책 목록 페이지에서는 넘겨주지 못해서, 
    providerId로 서재에 책 추가하는 API 새로 개발했습니다.
    -> (지금 서재 추가 API 대신 다 이걸로 쓰는 것도 가능할 것 같습니다 )
- 책 검색 목록에서 상태 변경을 위한 userbookId 응답에 추가했습니다.
- 프론트에서 책 상세-기본정보 조회에서 author, title 등 추가 정보 보내달라고 하셔서 응답에 추가했습니다.

+ 책정보 - 친구의 기록 조회할 때, bookInfoId로 조회하면 userId가 필요한데, 타유저의 userId를 받을 방법이 없어서 userbookId로 조회해야 할 것 같습니다. 이 부분도 수정했습니다!

