### PR TITLE
[Fix] 디자인/기획 변경사항에 따른 수정

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/request/ReviewCreateRequestDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/request/ReviewCreateRequestDto.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewCreateRequestDto {
-    @NotNull private String reviewTitle;
+    private String reviewTitle;
     @NotNull private String reviewContent;
     private String color;
     private Visibility visibility;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/Excerpt.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/Excerpt.java
@@ -6,6 +6,7 @@ import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +25,7 @@ public class Excerpt extends BaseTimeEntity {
     private Long excerptId;
 
     @NotNull
+    @Size(max = 300, message = "발췌 내용은 최대 300자까지 입력할 수 있습니다.")
     private String excerptContent;
 
     @Enumerated(EnumType.STRING)

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/Review.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/Review.java
@@ -32,6 +32,8 @@ public class Review extends BaseTimeEntity {
 
     private String color;
 
+    private boolean isSystemGenerated;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", updatable = false)
     @NotNull
@@ -61,5 +63,11 @@ public class Review extends BaseTimeEntity {
         this.color = color;
         this.visibility = visibility;
     }
+
+    public void setReviewTitle(String reviewTitle) {this.reviewTitle = reviewTitle;}
+
+    public void setIsSystemGenerated(boolean isSystemGenerated) {this.isSystemGenerated = isSystemGenerated;}
+
+
 
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/Review.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/entity/Review.java
@@ -6,6 +6,7 @@ import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
@@ -19,10 +20,11 @@ public class Review extends BaseTimeEntity {
     @Column(updatable = false)
     private Long reviewId;
 
-    @NotNull
+    @Size(max = 25, message = "리뷰 제목은 최대 25자까지 입력할 수 있습니다.")
     private String reviewTitle;
 
     @NotNull
+    @Size(max = 1000, message = "리뷰 내용은 최대 1000자까지 입력할 수 있습니다.")
     private String reviewContent;
 
     @Enumerated(EnumType.STRING)

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ReviewRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ReviewRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    List<Review> findByUserAndReviewTitleStartingWith(User user, String reviewTitle);;
+
     long countByUser(User user);
 
     @Query("SELECT COUNT(r) FROM Review r WHERE r.user = :user AND YEAR(r.createdTime) = :currentYear")

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ReviewService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ReviewService.java
@@ -17,6 +17,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.regex.Pattern;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -25,22 +30,41 @@ public class ReviewService {
     private final UserService userService;
     private final UserBookService userBookService;
 
+    // 생성
     public Review createReview(ReviewCreateRequestDto requestDto){
         User user = userService.getCurrentUser();
         UserBook userBook = userBookService.getUserBookById(requestDto.getUserBookId());
         String color = requestDto.getColor() != null ? requestDto.getColor() : "#FFFFFF";
         Visibility visibility = requestDto.getVisibility() != null ? requestDto.getVisibility() : Visibility.PUBLIC;
+        boolean isSystemGenerated = false;
+        // 제목 생성 로직
+        String reviewTitle = requestDto.getReviewTitle();
+        if (reviewTitle == null || reviewTitle.isBlank()) {
+            String dateTitle = formatDateTitle(userBook.getCreatedTime());
+            reviewTitle = generateUniqueTitle(user, dateTitle);
+            isSystemGenerated = true;
+        }
         Review review = requestDto.toEntity(user, userBook, color, visibility);
+        review.setReviewTitle(reviewTitle);
+        review.setIsSystemGenerated(isSystemGenerated);
         return reviewRepository.save(review);
     }
 
+    // 수정
     public Review updateReview(Long reviewId, ReviewUpdateRequestDto requestDto) {
         // 생성자 검증 archiveService.updateArchive에서 하고 있으므로 생략
         Review review = getReviewById(reviewId);
+        // 제목 업데이트 시 isSystemGenerated를 false로 변경
+        String newTitle = requestDto.reviewTitle();
+        if (newTitle != null && !newTitle.equals(review.getReviewTitle())) {
+            review.setReviewTitle(newTitle);
+            review.setIsSystemGenerated(false);
+        }
         review.updateReview(requestDto.reviewTitle(), requestDto.reviewContent(), requestDto.color(), requestDto.reviewVisibility());
         return review;
     }
 
+    // 삭제
     public void deleteReview(Long reviewId) {
         // 생성자 검증 archiveService.deleteArchive에서 하고 있으므로 생략
         Review review = getReviewById(reviewId);
@@ -51,5 +75,36 @@ public class ReviewService {
     public Review getReviewById(Long reviewId) {
         return reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+    }
+
+    public String formatDateTitle(LocalDateTime createdTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일의 기록");
+        return createdTime.format(formatter);
+    }
+
+    private String generateUniqueTitle(User user, String dateTitle) {
+        List<Review> existingReviews = reviewRepository.findByUserAndReviewTitleStartingWith(user, dateTitle);
+        if (existingReviews.isEmpty()) {
+            return dateTitle;
+        }
+        int maxSuffix = 0; // 숫자 접미사 설정
+        for (Review review : existingReviews) {
+            String title = review.getReviewTitle();
+            // 'yyyy년 mm월 dd의 기록' 제목이 이미 존재하는 경우
+            if (title.equals(dateTitle)) {
+                if (maxSuffix < 1) { maxSuffix = 1; }
+            }
+            // 시스템이 생성한 접미사 제목이 있는 경우
+            else if (title.matches(Pattern.quote(dateTitle) + "\\(\\d+\\)$")) {
+                String suffixStr = title.substring(title.lastIndexOf("(") + 1, title.lastIndexOf(")"));
+                try {
+                    int suffix = Integer.parseInt(suffixStr); // 접미사 추출
+                    if (suffix > maxSuffix) { maxSuffix = suffix; }
+                } catch (NumberFormatException e) {
+                    // 접미사가 숫자가 아닌 경우 무시
+                }
+            }
+        }
+        return maxSuffix == 0 ? dateTitle : dateTitle + "(" + (maxSuffix + 1) + ")";
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
@@ -15,6 +15,7 @@ import com.mmc.bookduck.domain.user.service.UserService;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/dto/response/OneLineRatingUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/dto/response/OneLineRatingUnitDto.java
@@ -2,10 +2,14 @@ package com.mmc.bookduck.domain.oneline.dto.response;
 
 import com.mmc.bookduck.domain.oneline.entity.OneLine;
 
+import java.time.LocalDateTime;
+
 public record OneLineRatingUnitDto(
         String oneLineContent,
         double rating,
         int oneLineLikes,
+        LocalDateTime createdTime,
+        Long userId,
         String userNickName
 ) {
     public static OneLineRatingUnitDto from(OneLine oneLine) {
@@ -13,6 +17,8 @@ public record OneLineRatingUnitDto(
                 oneLine.getOneLineContent(),
                 oneLine.getUserBook().getRating(),
                 oneLine.getOneLineLikes().size(),
+                oneLine.getCreatedTime(),
+                oneLine.getUser().getUserId(),
                 oneLine.getUser().getNickname()
         );
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/User.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/User.java
@@ -18,6 +18,7 @@ public class User extends BaseTimeEntity {
     @NotNull
     private String email;
 
+    @Enumerated(EnumType.STRING)
     @NotNull
     private LoginType loginType;
 
@@ -36,12 +37,12 @@ public class User extends BaseTimeEntity {
     private String fcmToken;
 
     @Builder
-    public User(Long userId, String email, LoginType loginType, String nickname) {
+    public User(Long userId, String email, LoginType loginType, Role role, String nickname) {
         this.userId = userId;
         this.email = email;
         this.loginType = loginType;
         this.nickname = nickname;
-        this.role = Role.ROLE_USER;
+        this.role = role != null ? role : Role.ROLE_USER;
         this.userStatus = UserStatus.ACTIVE;
     }
 
@@ -54,4 +55,5 @@ public class User extends BaseTimeEntity {
     public void setFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }
+
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserService.java
@@ -1,20 +1,30 @@
 package com.mmc.bookduck.domain.user.service;
 
+import com.mmc.bookduck.domain.user.entity.LoginType;
+import com.mmc.bookduck.domain.user.entity.Role;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.entity.UserStatus;
 import com.mmc.bookduck.domain.user.repository.UserRepository;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Value;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+
+    @Value("${official.account.email}")
+    private String officialAccountEmail;
+
+    @Value("${official.account.nickname}")
+    private String officialAccountNickname;
 
     @Transactional(readOnly = true)
     public User getCurrentUser() throws CustomException {
@@ -45,6 +55,21 @@ public class UserService {
     private void validateActiveUserStatus(User user) throws CustomException {
         if (!user.getUserStatus().equals(UserStatus.ACTIVE)) {
             throw new CustomException(ErrorCode.USER_STATUS_IS_NOT_ACTIVE);
+        }
+    }
+
+    // 공식계정 생성
+    @PostConstruct
+    @Transactional
+    public void createOfficialAccount() {
+        if (userRepository.findByEmail(officialAccountEmail).isEmpty()) {
+            User officialAccount = User.builder()
+                    .email(officialAccountEmail)
+                    .loginType(LoginType.GOOGLE)
+                    .nickname(officialAccountNickname)
+                    .role(Role.ROLE_ADMIN)
+                    .build();
+            userRepository.saveAndFlush(officialAccount);
         }
     }
 


### PR DESCRIPTION
# 구현 기능
- [x] 기록 - 제목null일 시 -> yyyy년 mm년 dd의 기록(1) (2) (3),..
REVIEW 엔티티에 boolean isSystemGenerated를 추가했습니다. 제목을 시스템이 만들었는지 아닌지를 판별하여 사용자가 악의적으로 제목을 'yyyy년 mm월 dd의 기록(12345)'으로 수정할 경우, 그 다음으로 생성된 제목이 'yyyy년 mm월 dd의 기록(12346)'이 되는 것을 방지합니다. 
- [x] 글자수 제한 : 감상평 1000자, 감상평제목 25자, 발췌 300자
- [x] 공식계정 친구 추가
- [x] 한줄평 모두보기 - userId, createdDate 추가
- [x] 유저 기록 아카이브 조회 - 전체, 발췌만, 감상평만 : responseDto 수정 -> title, author 추가 필요

# Resolve
  - #86 
