### PR TITLE
[Feat] 독서리포트 API 수정

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ExcerptRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ExcerptRepository.java
@@ -39,7 +39,8 @@ public interface ExcerptRepository extends JpaRepository<Excerpt, Long> {
             Pageable pageable);
 
 
-    @Query("SELECT e FROM Excerpt e WHERE e.user.id = :userId")
+    @Query("SELECT e FROM Excerpt e WHERE e.user.userId = :userId")
     List<Excerpt> findByUserId(@Param("userId") Long userId);
 
+    List<Excerpt> findTop30ByUserOrderByCreatedTimeDesc(User user);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ReviewRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/repository/ReviewRepository.java
@@ -29,6 +29,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findAllByUserAndCreatedTimeAfter(User user, LocalDateTime createdTime);
 
-    @Query("SELECT e FROM Review e WHERE e.user.id = :userId")
+    @Query("SELECT e FROM Review e WHERE e.user.userId = :userId")
     List<Review> findByUserId(@Param("userId") Long userId);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/repository/UserBookRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/repository/UserBookRepository.java
@@ -23,6 +23,7 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
     List<UserBook> findByUserAndReadStatus(User user, ReadStatus readStatus);
 
+    long countByUser(User user);
     long countByUserAndReadStatus(User user, ReadStatus readStatus);
 
     // userbook 테이블과 bookinfo 테이블 조인해서 userbook의 user에 해당하는 bookinfo 정보 검색
@@ -65,17 +66,15 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
             "ORDER BY bookCount DESC")
     List<Object[]> findMostReadAuthorByUser(@Param("user") User user);
 
-    // BookInfo의 작가명으로 UserBook 찾기
-    List<UserBook> findAllByBookInfo_Author(String author);
+    // BookInfo의 작가명으로 UserBook top3찾기
+    List<UserBook> findTop3ByBookInfo_AuthorOrderByCreatedTimeDesc(String author);
 
     // 유저의 UserBook들 올해 상반기/하반기별로 조회
     @Query("SELECT ub FROM UserBook ub WHERE ub.user = :user AND " +
             "((:isFirstHalf = true AND MONTH(ub.createdTime) BETWEEN 1 AND 6) OR " +
-            "(:isFirstHalf = false AND MONTH(ub.createdTime) BETWEEN 7 AND 12)) AND " +
-            "ub.readStatus = :readStatus")
-    List<UserBook> findAllByUserAndCreatedInHalfWithReadStatus(@Param("user") User user,
-                                                               @Param("isFirstHalf") boolean isFirstHalf,
-                                                               @Param("readStatus") ReadStatus readStatus);
+            "(:isFirstHalf = false AND MONTH(ub.createdTime) BETWEEN 7 AND 12))")
+    List<UserBook> findAllByUserAndCreatedInHalf(@Param("user") User user,
+                                                               @Param("isFirstHalf") boolean isFirstHalf);
 
     List<UserBook> findAllByBookInfoOrderByRatingDesc(BookInfo bookInfo);
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserReadingReportService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserReadingReportService.java
@@ -32,54 +32,50 @@ public class UserReadingReportService {
     private final ReviewRepository reviewRepository;
     private final UserService userService;
     private final KomoranService komoranService;
-
     public UserStatisticsResponseDto getUserStatistics(Long userId) {
+        // UserBook이 0권이라면 조회 불가능
         User user = userService.getActiveUserByUserId(userId);
+        long userBookCount = userBookRepository.countByUser(user);
+        if (userBookCount == 0) {
+            throw new CustomException(ErrorCode.READINGREPORT_NOT_VIEWABLE);
+        }
 
-        // 1. 가장 많이 읽은 카테고리, Top3 카테고리 // TODO: 카테고리? GenreName?
+        // 1. 가장 많이 읽은 카테고리, Top3 카테고리
         List<Object[]> topCategoryResults = userBookRepository.findTopCategoriesByUser(user, Pageable.ofSize(3));
         List<MostReadGenreUnitDto> mostReadGenres = topCategoryResults.stream()
                 .map(result -> new MostReadGenreUnitDto((String) result[0], (Long) result[1]))
                 .toList();
-        // 널 체크
         String duckTitle = mostReadGenres.isEmpty() ? null : mostReadGenres.get(0).genreName();
-
 
         // 2. 발췌 수, 감상평 수, 완독한 책 수
         long excerptCount = excerptRepository.countByUser(user);
         long reviewCount = reviewRepository.countByUser(user);
         long finishedBookCount = userBookRepository.countByUserAndReadStatus(user, ReadStatus.FINISHED);
 
-
         // 3. 올해 현재 분기(상반기/하반기) 월별 독서 수
         int currentMonth = java.time.LocalDate.now().getMonthValue();
         boolean isFirstHalfOfYear = (currentMonth <= 6);
-        // 해당 기간의 UserBook 조회 (TODO: ReadStatus 재확인 필요)
-        List<UserBook> userBooksForCurrentYearHalf = userBookRepository.findAllByUserAndCreatedInHalfWithReadStatus(user, isFirstHalfOfYear, ReadStatus.FINISHED);
-        // 월별 독서 수를 저장할 Map
+        // 해당 기간의 UserBook 조회 및 월별 책 권수 카운트
+        List<UserBook> userBooksForCurrentYearHalf = userBookRepository.findAllByUserAndCreatedInHalf(user, isFirstHalfOfYear);
         Map<Integer, Long> monthlyCounts = new HashMap<>();
-        // 각 책의 생성 월에 따라 카운트
         for (UserBook userBook : userBooksForCurrentYearHalf) {
             int month = userBook.getCreatedTime().getMonthValue();
             monthlyCounts.put(month, monthlyCounts.getOrDefault(month, 0L) + 1);
         }
-        // 월별 책 권수
         List<MonthlyBookCountUnitDto> monthlyBookCounts = monthlyCounts.entrySet().stream()
                 .map(entry -> new MonthlyBookCountUnitDto(entry.getKey(), entry.getValue()))
-                .sorted(Comparator.comparingInt(MonthlyBookCountUnitDto::month)) // 월 기준으로 정렬
+                .sorted(Comparator.comparingInt(MonthlyBookCountUnitDto::month))
                 .collect(Collectors.toList());
-
 
         // 4. 가장 많이 읽은 작가, 책표지들
         // 가장 많이 읽은 작가
         List<Object[]> topAuthorsResults = userBookRepository.findMostReadAuthorByUser(user);
         String mostReadAuthor = topAuthorsResults.isEmpty() ? null : (String) topAuthorsResults.get(0)[0];
         // 해당 작가의 책표지들
-        List<UserBook> mostReadAuthorBooks = userBookRepository.findAllByBookInfo_Author(mostReadAuthor);
+        List<UserBook> mostReadAuthorBooks = userBookRepository.findTop3ByBookInfo_AuthorOrderByCreatedTimeDesc(mostReadAuthor);
         List<String> imgPaths = mostReadAuthorBooks.stream()
                 .map(userBook -> userBook.getBookInfo().getImgPath())
                 .toList();
-
 
         return new UserStatisticsResponseDto(
                 user.getNickname(),
@@ -97,14 +93,10 @@ public class UserReadingReportService {
     }
 
     public List<String> getUserKeywordAnalysis(Long userId) {
-        // 유저 조회
         User user = userService.getActiveUserByUserId(userId);
-
-        // 감상평 및 발췌 가져오기
         List<Review> reviews = reviewRepository.findTop30ByUserOrderByCreatedTimeDesc(user);
         List<Excerpt> excerpts = excerptRepository.findTop30ByUserOrderByCreatedTimeDesc(user);
 
-        // 글자수 및 토큰화 동시에 처리
         int totalLength = 0;
         Map<String, Long> frequencyMap = new HashMap<>();
 
@@ -131,18 +123,15 @@ public class UserReadingReportService {
             throw new CustomException(ErrorCode.KEYWORD_NOT_VIEWABLE);
         }
 
-        // 키워드 빈도수 상위 6개 추출
+        // 키워드 6개 이상일 때만 조회 가능
         List<String> topKeywords = frequencyMap.entrySet().stream()
                 .sorted((e1, e2) -> Long.compare(e2.getValue(), e1.getValue()))
                 .limit(6)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
-
-        // 키워드가 6개 미만이면 예외 던지기
         if (topKeywords.size() < 6) {
             throw new CustomException(ErrorCode.KEYWORD_NOT_VIEWABLE);
         }
-
         return topKeywords;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     USERITEM_BAD_REQUEST(400, "유저의 소유가 아닌 userItemId입니다."),
     BOOKINFO_BAD_REQUEST(400, "API 도서가 아닌 bookInfoId입니다."),
     HOMECARD_BAD_REQUEST(400, "현재 카드 7개가 다 찼습니다."),
-    READINGREPORT_NOT_VIEWABLE(400, "아직 책이 없어 독서리포트를 볼 수 없습니다."),
+    READINGREPORT_NOT_VIEWABLE(400, "서재에 책이 없어 독서리포트를 볼 수 없습니다."),
     KEYWORD_NOT_VIEWABLE(400, "분석 가능한 키워드 갯수가 충분하지 않습니다."),
 
     // 401 Unauthorized

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     USERITEM_BAD_REQUEST(400, "유저의 소유가 아닌 userItemId입니다."),
     BOOKINFO_BAD_REQUEST(400, "API 도서가 아닌 bookInfoId입니다."),
     HOMECARD_BAD_REQUEST(400, "현재 카드 7개가 다 찼습니다."),
+    KEYWORD_NOT_VIEWABLE(400, "분석 가능한 키워드 갯수가 충분하지 않습니다."),
 
     // 401 Unauthorized
     // 로그인 상태여야 하는 요청

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     USERITEM_BAD_REQUEST(400, "유저의 소유가 아닌 userItemId입니다."),
     BOOKINFO_BAD_REQUEST(400, "API 도서가 아닌 bookInfoId입니다."),
     HOMECARD_BAD_REQUEST(400, "현재 카드 7개가 다 찼습니다."),
+    READINGREPORT_NOT_VIEWABLE(400, "아직 책이 없어 독서리포트를 볼 수 없습니다."),
     KEYWORD_NOT_VIEWABLE(400, "분석 가능한 키워드 갯수가 충분하지 않습니다."),
 
     // 401 Unauthorized


### PR DESCRIPTION
# 구현 기능
  - 독서리포트-키워드 조회가능 조건 추가 (추출가능 키워드 6개이상, 500자이상)
  - UserBook 없으면 독서리포트 조회 불가, 작가 책표지 top3만 전송