### PR TITLE
[Fix] 독서리포트를 장르가 category 아닌 genre로 계산되도록 수정, 쓰이지 않는 임포트 삭제

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/repository/UserBookRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/repository/UserBookRepository.java
@@ -54,13 +54,14 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
     List<UserBook> findAllByUser(User user);
 
-    // 유저가 가장 많이 읽은 카테고리들
-    @Query(value = "SELECT bi.category, COUNT(ub) FROM UserBook ub " +
+    // 유저가 가장 많이 읽은 장르들
+    @Query("SELECT g.genreName, COUNT(ub) FROM UserBook ub " +
             "JOIN ub.bookInfo bi " +
+            "JOIN bi.genre g " +
             "WHERE ub.user = :user " +
-            "GROUP BY bi.category " +
+            "GROUP BY g.genreName " +
             "ORDER BY COUNT(ub) DESC")
-    List<Object[]> findTopCategoriesByUser(@Param("user") User user, Pageable pageable);
+    List<Object[]> findTopGenresByUser(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT g.genreName " +
             "FROM UserBook ub " +

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
@@ -6,7 +6,6 @@ import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.friend.service.FriendService;
 import com.mmc.bookduck.domain.user.dto.response.UserGrowthInfoResponseDto;
 import com.mmc.bookduck.domain.user.dto.response.UserInfoResponseDto;
-import com.mmc.bookduck.domain.user.entity.Role;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.entity.UserGrowth;
 import com.mmc.bookduck.domain.user.repository.UserGrowthRepository;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserReadingReportService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserReadingReportService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,6 +32,7 @@ public class UserReadingReportService {
     private final ReviewRepository reviewRepository;
     private final UserService userService;
     private final KomoranService komoranService;
+
     public UserStatisticsResponseDto getUserStatistics(Long userId) {
         // UserBook이 0권이라면 조회 불가능
         User user = userService.getActiveUserByUserId(userId);
@@ -41,9 +41,9 @@ public class UserReadingReportService {
             throw new CustomException(ErrorCode.READINGREPORT_NOT_VIEWABLE);
         }
 
-        // 1. 가장 많이 읽은 카테고리, Top3 카테고리
-        List<Object[]> topCategoryResults = userBookRepository.findTopCategoriesByUser(user, Pageable.ofSize(3));
-        List<MostReadGenreUnitDto> mostReadGenres = topCategoryResults.stream()
+        // 1. 가장 많이 읽은 장르, Top3 장르
+        List<Object[]> topGenres = userBookRepository.findTopGenresByUser(user, Pageable.ofSize(3));
+        List<MostReadGenreUnitDto> mostReadGenres = topGenres.stream()
                 .map(result -> new MostReadGenreUnitDto((String) result[0], (Long) result[1]))
                 .toList();
         String duckTitle = mostReadGenres.isEmpty() ? null : mostReadGenres.get(0).genreName();
@@ -105,18 +105,14 @@ public class UserReadingReportService {
         for (Review review : reviews) {
             String reviewContent = review.getReviewContent();
             totalLength += reviewContent.length();
-            komoranService.extractNounsAndAdjectives(reviewContent).forEach(token -> {
-                frequencyMap.merge(token, 1L, Long::sum);
-            });
+            komoranService.extractNounsAndAdjectives(reviewContent).forEach(token -> frequencyMap.merge(token, 1L, Long::sum));
         }
 
         // 발췌에서 명사와 형용사를 추출하고 글자수 누적
         for (Excerpt excerpt : excerpts) {
             String excerptContent = excerpt.getExcerptContent();
             totalLength += excerptContent.length();
-            komoranService.extractNounsAndAdjectives(excerptContent).forEach(token -> {
-                frequencyMap.merge(token, 1L, Long::sum);
-            });
+            komoranService.extractNounsAndAdjectives(excerptContent).forEach(token -> frequencyMap.merge(token, 1L, Long::sum));
         }
 
         // 글자수 500자 이상 체크

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
@@ -4,7 +4,6 @@ import com.mmc.bookduck.domain.friend.service.FriendService;
 import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
 import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.dto.common.UserUnitDto;
-import com.mmc.bookduck.domain.user.entity.Role;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.repository.UserRepository;
 import com.mmc.bookduck.global.common.PaginatedResponseDto;


### PR DESCRIPTION
# 구현 기능
  - 독서리포트를 장르가 category 아닌 genre로 계산되도록 수정하고, 쓰이지 않는 임포트를 삭제했습니다.