### PR TITLE
[Fix] 유저 정보 조회 시 자기 자신인 경우 isFriend에 null 반환

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/common/UserUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/common/UserUnitDto.java
@@ -1,7 +1,6 @@
 package com.mmc.bookduck.domain.user.dto.common;
 
 import com.mmc.bookduck.domain.item.dto.common.ItemEquippedUnitDto;
-import com.mmc.bookduck.domain.user.entity.Role;
 import com.mmc.bookduck.domain.user.entity.User;
 
 import java.util.List;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
@@ -43,8 +43,10 @@ public class UserGrowthService {
         long excerptCount = excerptRepository.countByUserAndCreatedTimeThisYear(user, currentYear);
         long bookCount = (reviewCount + excerptCount);
         boolean isOfficial = user.isOfficial();
-
-        boolean isFriend = friendService.isFriendWithCurrentUserOrNull(user);
+        User currentUser = userService.getCurrentUserOrNull();
+        Boolean isFriend = (currentUser == null || !currentUser.equals(user))
+                ? friendService.isFriendWithCurrentUserOrNull(user)
+                : null;
         return new UserInfoResponseDto(user.getNickname(), bookCount, isOfficial, isFriend);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSearchService.java
@@ -36,7 +36,7 @@ public class UserSearchService {
         Page<UserUnitDto> userUnitDtoPage = userPage.map(user -> {
             List<ItemEquippedUnitDto> userItems = userItemService.getUserItemEquippedListOfUser(user);
             boolean isOfficial = user.isOfficial();
-            boolean isFriend = friendService.isFriendWithCurrentUserOrNull(user);
+            Boolean isFriend = friendService.isFriendWithCurrentUserOrNull(user);
             return UserUnitDto.from(user, userItems, isOfficial, isFriend);
         });
         return PaginatedResponseDto.from(userUnitDtoPage);


### PR DESCRIPTION
# 구현 기능
  - 기존 isFriend는 true/false만 반환하였는데, 유저 정보 조회 시 자기 자신인 경우 친구추가를 미표시하기 위해 isFriend에 null을 반환하도록 했습니다.