### PR TITLE
fix: api도서목록조회 페이지네이션 수정, 요즘많이읽는책에서 custom도서 제외

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
@@ -462,6 +462,9 @@ public class BookInfoService {
 
         Map<Long, Integer> bookInfoCountMap = new HashMap<>();
         for (UserBook userBook : userBookList) {
+            if( userBook.getBookInfo().getCreatedUserId() != null){
+                continue;
+            }
             Long bookInfoId = userBook.getBookInfo().getBookInfoId();
             bookInfoCountMap.put(bookInfoId, bookInfoCountMap.getOrDefault(bookInfoId, 0) + 1);
         }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
@@ -252,6 +252,10 @@ public class BookInfoService {
 
     // api bookInfo 저장
     public BookInfo saveApiBookInfo (UserBookRequestDto dto) {
+        Optional<BookInfo> existingBookInfo = findBookInfoByProviderId(dto.providerId());
+        if(existingBookInfo.isPresent()){
+            throw new CustomException(ErrorCode.BOOK_ALREADY_EXISTS);
+        }
 
         String saveAuthor = dto.author();
         Genre genre = genreService.findGenreById(dto.genreId());
@@ -562,6 +566,10 @@ public class BookInfoService {
 
         UserBook savedUserBook;
         if(bookInfo.isPresent()){
+            Optional<UserBook> existingUserBook = userBookRepository.findByUserAndBookInfo(user, bookInfo.get());
+            if(existingUserBook.isPresent()){
+                throw new CustomException(ErrorCode.USERBOOK_ALREADY_EXISTS);
+            }
             UserBook userBook = new UserBook(ReadStatus.NOT_STARTED, user, bookInfo.get());
             savedUserBook = userBookRepository.save(userBook);
         }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
@@ -22,7 +22,7 @@ public class GoogleBooksApiService {
     // 목록 검색
     public String searchBookList(String keyword, Long page, Long size) {
         try {
-            String url = "https://www.googleapis.com/books/v1/volumes?q=" + keyword + "&startIndex=" + page
+            String url = "https://www.googleapis.com/books/v1/volumes?q=" + keyword + "&startIndex=" + (page * size)
                     + "&maxResults=" + size + "&key=" + apiKey;
 
             // API GET 요청


### PR DESCRIPTION
# 구현 기능
  - api 도서 검색할 때, 코드가 책들이 중복 응답되게 되어있어서 중복응답되지 않게 수정했습니다
  - 요즘 많이 읽는 책 조회할때 custom 책 제외하는 걸로 수정했습니다
