### PR TITLE
[Feat] 일반 알림 모두 읽기 API 추가, SSE 알림 전송 시점 추가, 타 유저와의 관계 ENUM으로 관리 및 로직 추가 등

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/controller/AlarmController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/controller/AlarmController.java
@@ -36,10 +36,17 @@ public class AlarmController {
         return ResponseEntity.ok(alarmService.getCommonAlarms(pageable));
     }
 
-    @Operation(summary = "개별 알림 읽음 처리", description = "개별 알림을 읽음 처리합니다.")
+    @Operation(summary = "일반 알림 개별 읽음 처리", description = "일반 알림을 개별 읽음 처리합니다.")
     @PatchMapping("/common")
     public ResponseEntity<?> checkCommonAlarm(@RequestBody @Valid AlarmReadRequestDto requestDto) {
         alarmService.checkCommonAlarm(requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "일반 알림 모두 읽음 처리", description = "일반 알림을 모두 읽음 처리합니다.")
+    @PatchMapping("/common/all")
+    public ResponseEntity<?> checkAllCommonAlarm() {
+        alarmService.checkAllCommonAlarm();
         return ResponseEntity.ok().build();
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/common/AlarmUnitDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/common/AlarmUnitDto.java
@@ -21,7 +21,7 @@ public record AlarmUnitDto(
                 alarm.isRead(),
                 alarm.getAlarmType(),
                 alarm.getCreatedTime(),
-                alarm.getSender() != null ? alarm.getSender().getNickname() : alarm.getResourceValue(),
+                alarm.getAlarmType().extractBoldText(alarm),
                 alarm.getResourceName(),
                 alarm.getResourceId()
         );

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/AlarmDefaultDataDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/AlarmDefaultDataDto.java
@@ -5,9 +5,9 @@ public record AlarmDefaultDataDto(
         Boolean isAnnouncementChecked,
         Boolean isItemUnlockedChecked
 ) {
-    public static AlarmDefaultDataDto from (Boolean isCommonAlarmChecked,
-                                            Boolean isAnnouncementChecked,
-                                            Boolean isItemUnlockedChecked) {
+    public static AlarmDefaultDataDto from (boolean isCommonAlarmChecked,
+                                            boolean isAnnouncementChecked,
+                                            boolean isItemUnlockedChecked) {
         return new AlarmDefaultDataDto(isCommonAlarmChecked, isAnnouncementChecked, isItemUnlockedChecked);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
@@ -3,6 +3,8 @@ package com.mmc.bookduck.domain.alarm.entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.text.MessageFormat;
+
 @Getter
 @AllArgsConstructor
 public enum AlarmType {
@@ -19,14 +21,14 @@ public enum AlarmType {
     private final String messagePattern;
     private final boolean sendPush;
 
-    // 메시지 생성 메서드
-//    public String generateMessage(Alarm alarm) {
-//        return switch (this) {
-//            case FRIEND_REQUEST, FRIEND_APPROVED, ONELINELIKE_ADDED, BADGE_UNLOCKED ->
-//                    MessageFormat.format(messagePattern, alarm.getSender().getNickname());
-//            case LEVEL_UP ->
-//                    MessageFormat.format(messagePattern, alarm.getResourceValue());
-//            default -> messagePattern;
-//        };
-//    }
+    // boldText 생성 메서드
+    public String extractBoldText(Alarm alarm) {
+        return switch (this) {
+            case FRIEND_REQUEST, FRIEND_APPROVED, ONELINELIKE_ADDED, BADGE_UNLOCKED ->
+                    MessageFormat.format("{0}", alarm.getSender().getNickname());
+            case LEVEL_UP ->
+                    MessageFormat.format("{0}", alarm.getResourceValue());
+            default -> "";
+        };
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Boolean existsByReceiverAndIsReadFalse(User user);
@@ -21,4 +22,6 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     void deleteAllBySender(User user);
     void deleteAllByReceiver(User user);
     void deleteByCreatedTimeBefore(LocalDateTime createdTime);
+
+    List<Alarm> findAllByReceiverAndIsReadFalse(User user);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmByTypeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmByTypeService.java
@@ -3,6 +3,7 @@ package com.mmc.bookduck.domain.alarm.service;
 import com.mmc.bookduck.domain.alarm.entity.Alarm;
 import com.mmc.bookduck.domain.alarm.entity.AlarmType;
 import com.mmc.bookduck.domain.badge.entity.BadgeType;
+import com.mmc.bookduck.domain.book.entity.BookInfo;
 import com.mmc.bookduck.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -46,9 +47,9 @@ public class AlarmByTypeService {
         alarmService.createAlarm(alarm, receiver);
     }
     // 한줄평 좋아요 알림 생성
-    public void createOneLineLikeAlarm(User sender, User receiver, Long bookInfoId) {
+    public void createOneLineLikeAlarm(User sender, User receiver, BookInfo bookInfo) {
         AlarmType alarmType = AlarmType.ONELINELIKE_ADDED;
-        String message = MessageFormat.format(alarmType.getMessagePattern(), sender.getNickname());
+        String message = MessageFormat.format(alarmType.getMessagePattern(), bookInfo.getTitle());
 
         Alarm alarm = Alarm.builder()
                 .alarmType(alarmType)
@@ -56,7 +57,7 @@ public class AlarmByTypeService {
                 .receiver(receiver)
                 .message(message)
                 .resourceName("BookInfo")
-                .resourceId(bookInfoId)
+                .resourceId(bookInfo.getBookInfoId())
                 .build();
         alarmService.createAlarm(alarm, receiver);
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AnnouncementService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AnnouncementService.java
@@ -18,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnnouncementService {
     private final AnnouncementRepository announcementRepository;
     private final UserService userService;
+    private final EmitterService emitterService;
 
-    @Transactional(readOnly = true)
     public PaginatedResponseDto<AnnouncementUnitDto> getRecentAnnouncements(Pageable pageable) {
         // user가 공지 읽음으로 표시
         User user = userService.getCurrentUser();
@@ -27,6 +27,7 @@ public class AnnouncementService {
 
         Page<Announcement> announcementPage = announcementRepository.findByOrderByCreatedTimeDesc(pageable);
         Page<AnnouncementUnitDto> annoucementUnitDtos = announcementPage.map(AnnouncementUnitDto::new);
+        emitterService.sendToClientIfNewAlarmExists(user);
         return PaginatedResponseDto.from(annoucementUnitDtos);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AnnouncementService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AnnouncementService.java
@@ -23,11 +23,13 @@ public class AnnouncementService {
     public PaginatedResponseDto<AnnouncementUnitDto> getRecentAnnouncements(Pageable pageable) {
         // user가 공지 읽음으로 표시
         User user = userService.getCurrentUser();
-        user.setIsAnnouncementChecked(true);
-
+        // 공지를 안 읽었던 경우만, 상태 업데이트 및 SSE 알림 전송
+        if (!user.getIsAnnouncementChecked()) {
+            user.setIsAnnouncementChecked(true);
+            emitterService.sendToClientIfNewAlarmExists(user);
+        }
         Page<Announcement> announcementPage = announcementRepository.findByOrderByCreatedTimeDesc(pageable);
         Page<AnnouncementUnitDto> annoucementUnitDtos = announcementPage.map(AnnouncementUnitDto::new);
-        emitterService.sendToClientIfNewAlarmExists(user);
         return PaginatedResponseDto.from(annoucementUnitDtos);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
@@ -37,10 +37,10 @@ public class EmitterService {
         return emitter;
     }
 
-    private void sendToClientIfNewAlarmExists(User user) {
-        Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(user);
-        Boolean isAnnouncementChecked = user.getIsAnnouncementChecked();
-        Boolean isItemUnlockedChecked = user.getIsItemUnlockedChecked();
+    public void sendToClientIfNewAlarmExists(User user) {
+        boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(user);
+        boolean isAnnouncementChecked = user.getIsAnnouncementChecked();
+        boolean isItemUnlockedChecked = user.getIsItemUnlockedChecked();
         String messsage;
 
         if (isMissedAlarms || isAnnouncementChecked || isItemUnlockedChecked) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
@@ -23,7 +23,7 @@ public class EmitterService {
     private final AlarmRepository alarmRepository;
     private final UserService userService;
 
-    private static final Long DEFAULT_TIMEOUT = 5L * 60 * 1000;  // 5분
+    private static final Long DEFAULT_TIMEOUT = 3L * 60 * 1000;  // 3분
 
     public SseEmitter subscribe() {
         User user = userService.getCurrentUser();

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
@@ -37,18 +37,17 @@ public class EmitterService {
         return emitter;
     }
 
+    // 알림 상태를 확인하고 클라이언트에 알림 전송
     public void sendToClientIfNewAlarmExists(User user) {
         boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(user);
         boolean isAnnouncementChecked = user.getIsAnnouncementChecked();
         boolean isItemUnlockedChecked = user.getIsItemUnlockedChecked();
-        String messsage;
 
-        if (isMissedAlarms || isAnnouncementChecked || isItemUnlockedChecked) {
-            messsage = "new sse alarm exists";
-        } else {
-            messsage = "new sse alarm doesn't exists";
-        }
-        sendToClient(user.getUserId(), AlarmDefaultDataDto.from(!isMissedAlarms, isAnnouncementChecked, isItemUnlockedChecked), messsage);
+        String message = (isMissedAlarms || isAnnouncementChecked || isItemUnlockedChecked)
+                ? "new sse alarm exists"
+                : "new sse alarm doesn't exists";
+
+        sendToClient(user.getUserId(), AlarmDefaultDataDto.from(!isMissedAlarms, isAnnouncementChecked, isItemUnlockedChecked), message);
     }
 
     private void sendToClientIfBadgeUnlockedAlarmExists(User user) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendRequestService.java
@@ -115,4 +115,15 @@ public class FriendRequestService {
         request.setFriendRequestStatus(FriendRequestStatus.REJECTED);
         friendRequestRepository.save(request);
     }
+
+    @Transactional(readOnly = true)
+    public FriendRequest getPendingFriendRequestBetweenUsers(User currentUser, User targetUser) {
+        List<FriendRequest> existingRequests = friendRequestRepository.findAllFriendRequestsBetweenUsers(
+                currentUser.getUserId(), targetUser.getUserId(), FriendRequestStatus.PENDING);
+        if (existingRequests.isEmpty()) {
+            return null;  // 요청이 없다면 null 반환
+        }
+        // 친구 요청 1개(1개여야만 함)를 반환
+        return existingRequests.getFirst();
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/onelineLike/service/OneLineLikeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/onelineLike/service/OneLineLikeService.java
@@ -36,7 +36,7 @@ public class OneLineLikeService {
         oneLine.addOneLineLike(oneLineLike);
         // 타 사용자일 떄만 알림 전송
         if (!currentUser.equals(oneLine.getUser()))
-            alarmByTypeService.createOneLineLikeAlarm(currentUser, oneLine.getUser(), oneLine.getUserBook().getBookInfo().getBookInfoId());
+            alarmByTypeService.createOneLineLikeAlarm(currentUser, oneLine.getUser(), oneLine.getUserBook().getBookInfo());
         oneLineLikeRepository.save(oneLineLike);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/response/UserInfoResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/dto/response/UserInfoResponseDto.java
@@ -1,9 +1,11 @@
 package com.mmc.bookduck.domain.user.dto.response;
 
+import com.mmc.bookduck.domain.user.entity.UserRelationshipStatus;
+
 public record UserInfoResponseDto (
         String nickname,
         long bookCount,
         Boolean isOfficial,
-        Boolean isFriend
+        UserRelationshipStatus userRelationshipStatus
 ) {
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/User.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/User.java
@@ -36,8 +36,10 @@ public class User extends BaseTimeEntity {
 
     private String fcmToken;
 
+    @NotNull
     private Boolean isAnnouncementChecked;
 
+    @NotNull
     private Boolean isItemUnlockedChecked;
     
     @ColumnDefault("false")

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/UserRelationshipStatus.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/UserRelationshipStatus.java
@@ -1,0 +1,9 @@
+package com.mmc.bookduck.domain.user.entity;
+
+public enum UserRelationshipStatus {
+    NONE,               // 관계 없음
+    PENDING,           // 요청 중
+    ACCEPT,            // 수락하기
+    FRIEND,            // 친구
+    SELF              // 나
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
@@ -8,6 +8,7 @@ import com.mmc.bookduck.domain.user.dto.response.UserGrowthInfoResponseDto;
 import com.mmc.bookduck.domain.user.dto.response.UserInfoResponseDto;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.entity.UserGrowth;
+import com.mmc.bookduck.domain.user.entity.UserRelationshipStatus;
 import com.mmc.bookduck.domain.user.repository.UserGrowthRepository;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
@@ -25,7 +26,7 @@ public class UserGrowthService {
     private final ExcerptRepository excerptRepository;
     private final ReviewRepository reviewRepository;
     private final UserService userService;
-    private final FriendService friendService;
+    private final UserRelationshipService userRelationshipService;
 
     @Transactional(readOnly = true)
     public UserGrowth getUserGrowthByUserId(Long userId)
@@ -44,11 +45,12 @@ public class UserGrowthService {
         long bookCount = (reviewCount + excerptCount);
         boolean isOfficial = user.isOfficial();
         User currentUser = userService.getCurrentUserOrNull();
-        Boolean isFriend = (currentUser == null || !currentUser.equals(user))
-                ? friendService.isFriendWithCurrentUserOrNull(user)
-                : null;
-        return new UserInfoResponseDto(user.getNickname(), bookCount, isOfficial, isFriend);
+
+        // 유저와의 관계 상태 계산
+        UserRelationshipStatus userRelationshipStatus = userRelationshipService.getUserRelationshipStatus(currentUser, user);
+        return new UserInfoResponseDto(user.getNickname(), bookCount, isOfficial, userRelationshipStatus);
     }
+
 
     @Transactional(readOnly = true)
     public UserGrowthInfoResponseDto getUserLevelInfo(Long userId) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserRelationshipService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserRelationshipService.java
@@ -1,0 +1,42 @@
+package com.mmc.bookduck.domain.user.service;
+
+import com.mmc.bookduck.domain.friend.entity.FriendRequest;
+import com.mmc.bookduck.domain.friend.entity.FriendRequestStatus;
+import com.mmc.bookduck.domain.friend.service.FriendRequestService;
+import com.mmc.bookduck.domain.friend.service.FriendService;
+import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.entity.UserRelationshipStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserRelationshipService {
+    private final FriendService friendService;
+    private final FriendRequestService friendRequestService;
+
+    @Transactional(readOnly = true)
+    public UserRelationshipStatus getUserRelationshipStatus(User currentUser, User targetUser) {
+        if (currentUser == null) {
+            return UserRelationshipStatus.NONE;  // 비로그인 상태
+        }
+        if (currentUser.equals(targetUser)) {
+            return UserRelationshipStatus.SELF;  // 본인
+        }
+        if (friendService.isFriendWithCurrentUserOrNull(targetUser)) {
+            return UserRelationshipStatus.FRIEND;  // 친구
+        }
+
+        // 친구 요청 상태 구별
+        FriendRequest friendRequest = friendRequestService.getPendingFriendRequestBetweenUsers(currentUser, targetUser);
+        if (friendRequest != null && friendRequest.getFriendRequestStatus() == FriendRequestStatus.PENDING) {
+            if (friendRequest.getSender().equals(currentUser)) {
+                return UserRelationshipStatus.PENDING;  // 요청 보낸 사용자 -> 요청 중
+            } else {
+                return UserRelationshipStatus.ACCEPT;  // 요청 받은 사용자 -> 수락하기
+            }
+        }
+        return UserRelationshipStatus.NONE;  // 관계 없음
+    }
+}


### PR DESCRIPTION
# 구현 기능
  - 일반 알림 모두 읽기 API를 개발했습니다.
  - 알림 읽는 API들 호출시 SSE 알림 전송 시점을 추가했습니다.
  - 유저 정보 조회 API를 위해 타 유저와의 관계를 UserRelationshipStatus ENUM으로 관리하고 관련 로직을 추가했습니다.
  - UserSetting의 isPushAlarmEnabled이 true일때만 푸시알림 보내도록 했습니다.