### PR TITLE
[Hotfix] 친구삭제시 친구요청이 null일때 에러 발생 제거(공식계정 친구삭제의 경우 고려)

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/friend/service/FriendService.java
@@ -89,13 +89,11 @@ public class FriendService {
         // 친구 요청 상태를 BREAKUP로 변경
         List<FriendRequest> requests = friendRequestRepository.findAllFriendRequestsBetweenUsers(
                 friend.getUser1().getUserId(), friend.getUser2().getUserId(), FriendRequestStatus.ACCEPTED);
-        if (requests.isEmpty()) {
-            throw new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND);
+        if (!requests.isEmpty()) {
+            FriendRequest request = requests.get(0);  // 여러 개가 있을 경우, 가장 최근 요청을 처리
+            request.setFriendRequestStatus(FriendRequestStatus.BREAKUP);
+            friendRequestRepository.save(request);
         }
-        FriendRequest request = requests.get(0);  // 여러 개가 있을 경우, 가장 최근 요청을 처리
-        request.setFriendRequestStatus(FriendRequestStatus.BREAKUP);
-        friendRequestRepository.save(request);
-
         friendRepository.delete(friend);
     }
 


### PR DESCRIPTION
# 구현 기능
  - 친구삭제시 친구요청이 null일때 에러 발생 제거(공식계정 친구삭제의 경우 고려)

# Resolve
  - #86 
