### PR TITLE
[Feat] SSE 알림 구독 API 응답 수정, 응답 객체 수정, 아이템 알림 AlarmType에 추가 등

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/AlarmBadgeUnlockedDataDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/AlarmBadgeUnlockedDataDto.java
@@ -1,9 +1,0 @@
-package com.mmc.bookduck.domain.alarm.dto.ssedata;
-
-public record AlarmBadgeUnlockedDataDto(
-        Boolean isBadgeUnlockedChecked
-) {
-    public static AlarmBadgeUnlockedDataDto from (Boolean isBadgeUnlockedChecked) {
-        return new AlarmBadgeUnlockedDataDto(isBadgeUnlockedChecked);
-    }
-}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/AlarmDefaultDataDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/AlarmDefaultDataDto.java
@@ -3,11 +3,21 @@ package com.mmc.bookduck.domain.alarm.dto.ssedata;
 public record AlarmDefaultDataDto(
         Boolean isCommonAlarmChecked,
         Boolean isAnnouncementChecked,
-        Boolean isItemUnlockedChecked
+        Boolean isItemUnlockedChecked,
+        Boolean isLevelUpChecked,
+        Boolean isBadgeUnlockedChecked,
+        Integer newLevel,
+        BadgeModalInfo newBadgeInfo
 ) {
-    public static AlarmDefaultDataDto from (boolean isCommonAlarmChecked,
-                                            boolean isAnnouncementChecked,
-                                            boolean isItemUnlockedChecked) {
-        return new AlarmDefaultDataDto(isCommonAlarmChecked, isAnnouncementChecked, isItemUnlockedChecked);
+    public static AlarmDefaultDataDto fromDefault (boolean isCommonAlarmChecked, boolean isAnnouncementChecked, boolean isItemUnlockedChecked) {
+        return new AlarmDefaultDataDto(isCommonAlarmChecked, isAnnouncementChecked, isItemUnlockedChecked, true, true, null, null);
+    }
+
+    public static AlarmDefaultDataDto fromLevelUp (boolean isCommonAlarmChecked, boolean isAnnouncementChecked, int newLevel) {
+        return new AlarmDefaultDataDto(isCommonAlarmChecked, isAnnouncementChecked, true, false, true, newLevel, null);
+    }
+
+    public static AlarmDefaultDataDto fromBadgeUnlocked (boolean isCommonAlarmChecked, boolean isAnnouncementChecked, BadgeModalInfo newBadgeInfo) {
+        return new AlarmDefaultDataDto(isCommonAlarmChecked, isAnnouncementChecked, true, true, false, null, newBadgeInfo);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/BadgeModalInfo.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/dto/ssedata/BadgeModalInfo.java
@@ -1,0 +1,10 @@
+package com.mmc.bookduck.domain.alarm.dto.ssedata;
+
+import com.mmc.bookduck.domain.badge.entity.BadgeType;
+
+public record BadgeModalInfo(
+        BadgeType badgeType,
+        String badgeName,
+        String description
+) {
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
@@ -15,6 +15,7 @@ public enum AlarmType {
     ONELINELIKE_ADDED("{0}의 한줄평에 좋아요가 눌렸어요.", true),
     LEVEL_UP("야호! 오리가 Lv.{0}로 성장했어요.", false),
     BADGE_UNLOCKED("축하합니다! \uD83C\uDF89 새로운 {0} 뱃지를 획득했어요.", false),
+    ITEM_UNLOCKED("새로운 아이템을 획득했어요. 얼른 착용해봐요!", false),
     PUSH("",true), // 기타 푸시알림
     ;
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/entity/AlarmType.java
@@ -13,8 +13,8 @@ public enum AlarmType {
     FRIEND_REQUEST("{0}님으로부터 친구요청이 도착했어요!", true),
     FRIEND_APPROVED("{0}님이 친구요청을 수락했어요.", true),
     ONELINELIKE_ADDED("{0}의 한줄평에 좋아요가 눌렸어요.", true),
-    LEVEL_UP("야호! 오리가 Lv.{0}로 성장했어요.", true),
-    BADGE_UNLOCKED("축하합니다! \uD83C\uDF89 새로운 {0} 뱃지를 획득했어요.", true),
+    LEVEL_UP("야호! 오리가 Lv.{0}로 성장했어요.", false),
+    BADGE_UNLOCKED("축하합니다! \uD83C\uDF89 새로운 {0} 뱃지를 획득했어요.", false),
     PUSH("",true), // 기타 푸시알림
     ;
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/repository/AlarmRepository.java
@@ -1,7 +1,6 @@
 package com.mmc.bookduck.domain.alarm.repository;
 
 import com.mmc.bookduck.domain.alarm.entity.Alarm;
-import com.mmc.bookduck.domain.alarm.entity.AlarmType;
 import com.mmc.bookduck.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +13,6 @@ import java.util.List;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Boolean existsByReceiverAndIsReadFalse(User user);
-    Boolean existsByReceiverAndIsReadFalseAndAlarmType(User user, AlarmType badgeUnlocked);
 
     @Query("SELECT a FROM Alarm a WHERE a.receiver = :user ORDER BY a.createdTime DESC")
     Page<Alarm> findByReceiverOrderByCreatedTimeDesc(@Param("user") User user, Pageable pageable);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmByTypeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmByTypeService.java
@@ -1,8 +1,10 @@
 package com.mmc.bookduck.domain.alarm.service;
 
+import com.mmc.bookduck.domain.alarm.dto.ssedata.BadgeModalInfo;
 import com.mmc.bookduck.domain.alarm.entity.Alarm;
 import com.mmc.bookduck.domain.alarm.entity.AlarmType;
 import com.mmc.bookduck.domain.badge.entity.BadgeType;
+import com.mmc.bookduck.domain.badge.entity.UserBadge;
 import com.mmc.bookduck.domain.book.entity.BookInfo;
 import com.mmc.bookduck.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +48,7 @@ public class AlarmByTypeService {
                 .build();
         alarmService.createAlarm(alarm, receiver);
     }
+
     // 한줄평 좋아요 알림 생성
     public void createOneLineLikeAlarm(User sender, User receiver, BookInfo bookInfo) {
         AlarmType alarmType = AlarmType.ONELINELIKE_ADDED;
@@ -62,8 +65,9 @@ public class AlarmByTypeService {
         alarmService.createAlarm(alarm, receiver);
     }
 
+    // 푸시 알림이 발생하지 않는 알림들
     // 레벨업 알림 생성
-    public void createLevelUpAlarm(User receiver, Long level) {
+    public void createLevelUpAlarm(User receiver, int level) {
         AlarmType alarmType = AlarmType.LEVEL_UP;
         String message = MessageFormat.format(alarmType.getMessagePattern(), level);
 
@@ -72,14 +76,16 @@ public class AlarmByTypeService {
                 .receiver(receiver)
                 .message(message)
                 .resourceName("UserGrowth")
-                .resourceValue(level.toString())
+                .resourceValue(String.valueOf(level))
                 .build();
-        alarmService.createAlarm(alarm, receiver);
+        alarm.readAlarm();
+        alarmService.createLevelUpAlarm(alarm, receiver, level);
     }
 
     // 뱃지 잠금해제 알림 생성
-    public void createBadgeUnlockAlarm(User receiver, BadgeType badgeType) {
+    public void createBadgeUnlockedAlarm(User receiver, UserBadge userBadge) {
         AlarmType alarmType = AlarmType.BADGE_UNLOCKED;
+        BadgeType badgeType =  userBadge.getBadge().getBadgeType();
         String message = MessageFormat.format(alarmType.getMessagePattern(), badgeType.getTitle());
 
         Alarm alarm = Alarm.builder()
@@ -88,6 +94,27 @@ public class AlarmByTypeService {
                 .message(message)
                 .resourceName("Badge")
                 .build();
+        alarm.readAlarm();
+
+        String description = String.format("%s을 달성하여\n%s 배지를 얻었어요.",
+                MessageFormat.format(badgeType.getModalMessage(), userBadge.getBadge().getUnlockCondition()),
+                badgeType.getTitle());
+        BadgeModalInfo badgeModalInfo = new BadgeModalInfo(badgeType, userBadge.getBadge().getBadgeName(), description);
+        alarmService.createBadgeUnlockedAlarm(alarm, receiver, badgeModalInfo);
+    }
+
+    // 레벨업 알림 생성
+    public void createItemUnlockedAlarm(User receiver) {
+        AlarmType alarmType = AlarmType.ITEM_UNLOCKED;
+        String message = alarmType.getMessagePattern();
+
+        Alarm alarm = Alarm.builder()
+                .alarmType(alarmType)
+                .receiver(receiver)
+                .message(message)
+                .resourceName("Item")
+                .build();
+        alarm.readAlarm();
         alarmService.createAlarm(alarm, receiver);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AlarmService.java
@@ -2,6 +2,7 @@ package com.mmc.bookduck.domain.alarm.service;
 
 import com.mmc.bookduck.domain.alarm.dto.request.AlarmReadRequestDto;
 import com.mmc.bookduck.domain.alarm.dto.common.AlarmUnitDto;
+import com.mmc.bookduck.domain.alarm.dto.ssedata.BadgeModalInfo;
 import com.mmc.bookduck.domain.alarm.entity.Alarm;
 import com.mmc.bookduck.domain.alarm.repository.AlarmRepository;
 import com.mmc.bookduck.domain.user.entity.User;
@@ -54,7 +55,7 @@ public class AlarmService {
         if (!alarm.isRead()) {
             alarm.readAlarm();
             alarmRepository.save(alarm);
-            emitterService.sendToClientIfNewAlarmExists(user);
+            emitterService.sendToClientDefaultAlarm(user);
         }
     }
 
@@ -63,9 +64,25 @@ public class AlarmService {
         // 알림 저장
         alarmRepository.save(alarm);
         // SSE 알림을 클라이언트로 전송
-        emitterService.sendToClientIfNewAlarmExists(receiver);
+        emitterService.sendToClientDefaultAlarm(receiver);
         // 푸시 알림 전송
         sendPushNotificationIfEnabled(receiver, alarm);
+    }
+
+    // Alarm 생성
+    public void createLevelUpAlarm(Alarm alarm, User receiver, int level) {
+        // 알림 저장
+        alarmRepository.save(alarm);
+        // SSE 알림을 클라이언트로 전송
+        emitterService.sendToClientLevelUpAlarm(receiver, level);
+    }
+
+    // Alarm 생성
+    public void createBadgeUnlockedAlarm(Alarm alarm, User receiver, BadgeModalInfo badgeModalInfo) {
+        // 알림 저장
+        alarmRepository.save(alarm);
+        // SSE 알림을 클라이언트로 전송
+        emitterService.sendToClientBadgeUnlockedAlarm(receiver, badgeModalInfo);
     }
 
     // 푸시 알림 전송
@@ -94,6 +111,6 @@ public class AlarmService {
             alarmRepository.saveAll(alarms);
         }
         // SSE 알림 전송
-        emitterService.sendToClientIfNewAlarmExists(user);
+        emitterService.sendToClientDefaultAlarm(user);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AnnouncementService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/AnnouncementService.java
@@ -26,7 +26,7 @@ public class AnnouncementService {
         // 공지를 안 읽었던 경우만, 상태 업데이트 및 SSE 알림 전송
         if (!user.getIsAnnouncementChecked()) {
             user.setIsAnnouncementChecked(true);
-            emitterService.sendToClientIfNewAlarmExists(user);
+            emitterService.sendToClientDefaultAlarm(user);
         }
         Page<Announcement> announcementPage = announcementRepository.findByOrderByCreatedTimeDesc(pageable);
         Page<AnnouncementUnitDto> annoucementUnitDtos = announcementPage.map(AnnouncementUnitDto::new);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
@@ -1,7 +1,8 @@
 package com.mmc.bookduck.domain.alarm.service;
 
-import com.mmc.bookduck.domain.alarm.dto.ssedata.AlarmBadgeUnlockedDataDto;
 import com.mmc.bookduck.domain.alarm.dto.ssedata.AlarmDefaultDataDto;
+import com.mmc.bookduck.domain.alarm.dto.ssedata.BadgeModalInfo;
+import com.mmc.bookduck.domain.alarm.entity.Alarm;
 import com.mmc.bookduck.domain.alarm.entity.AlarmType;
 import com.mmc.bookduck.domain.alarm.repository.AlarmRepository;
 import com.mmc.bookduck.domain.alarm.repository.EmitterRepository;
@@ -33,36 +34,40 @@ public class EmitterService {
         SseEmitter emitter = Optional.ofNullable(emitterRepository.get(userId))
                 .orElseGet(() -> registerEmitter(userId));
 
-        sendToClientIfNewAlarmExists(user);
+        sendToClientDefaultAlarm(user);
         return emitter;
     }
 
-    // 알림 상태를 확인하고 클라이언트에 알림 전송
-    public void sendToClientIfNewAlarmExists(User user) {
-        boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(user);
-        boolean isAnnouncementChecked = user.getIsAnnouncementChecked();
-        boolean isItemUnlockedChecked = user.getIsItemUnlockedChecked();
-
-        String message = (isMissedAlarms || isAnnouncementChecked || isItemUnlockedChecked)
-                ? "new sse alarm exists"
-                : "new sse alarm doesn't exists";
-        
-        // 아이템 잠금 해제를 확인한 것으로 저장
-        if (isItemUnlockedChecked) {
-            user.setIsItemUnlockedChecked(true);
-            userService.saveUser(user);
-        }
-        
-        sendToClient(user.getUserId(), AlarmDefaultDataDto.from(!isMissedAlarms, isAnnouncementChecked, isItemUnlockedChecked), message);
+    // 기본 알림 전송
+    public void sendToClientDefaultAlarm(User user) {
+        boolean isCommonAlarmChecked = !alarmRepository.existsByReceiverAndIsReadFalse(user);
+        AlarmDefaultDataDto alarmDataDto = AlarmDefaultDataDto
+                .fromDefault(isCommonAlarmChecked, user.getIsAnnouncementChecked(), false);
+        sendToClient(user.getUserId(), alarmDataDto, "new sse alarm exists");
     }
 
-    private void sendToClientIfBadgeUnlockedAlarmExists(User user) {
-        Boolean isBadgeUnlocked = alarmRepository.existsByReceiverAndIsReadFalseAndAlarmType(user, AlarmType.BADGE_UNLOCKED);
-        if (isBadgeUnlocked.equals(true)) {
-            sendToClient(user.getUserId(), AlarmBadgeUnlockedDataDto.from(false), "new badge alarm exists");
-        } else {
-            sendToClient(user.getUserId(), AlarmBadgeUnlockedDataDto.from(true), "new badge alarm doesn't exists");
-        }
+    // 아이템 획득 알림 전송
+    public void sendToClientItemUnlockedAlarm(User user) {
+        boolean isCommonAlarmChecked = !alarmRepository.existsByReceiverAndIsReadFalse(user);
+        AlarmDefaultDataDto alarmDataDto = AlarmDefaultDataDto
+                .fromDefault(isCommonAlarmChecked, user.getIsAnnouncementChecked(), true);
+        sendToClient(user.getUserId(), alarmDataDto, "item unlocked alarm exists");
+    }
+
+    // 레벨업 알림 전송
+    public void sendToClientLevelUpAlarm(User user, int level) {
+        boolean isCommonAlarmChecked = !alarmRepository.existsByReceiverAndIsReadFalse(user);
+        AlarmDefaultDataDto alarmDataDto = AlarmDefaultDataDto
+                .fromLevelUp(isCommonAlarmChecked, user.getIsAnnouncementChecked(), level);
+        sendToClient(user.getUserId(), alarmDataDto, "level up alarm exists");
+    }
+
+    // 뱃지 획득 알림 전송
+    public void sendToClientBadgeUnlockedAlarm(User user, BadgeModalInfo badgeModalInfo) {
+        boolean isCommonAlarmChecked = !alarmRepository.existsByReceiverAndIsReadFalse(user);
+        AlarmDefaultDataDto alarmDataDto = AlarmDefaultDataDto
+                .fromBadgeUnlocked(isCommonAlarmChecked, user.getIsAnnouncementChecked(), badgeModalInfo);
+        sendToClient(user.getUserId(), alarmDataDto, "badge unlocked alarm exists");
     }
 
     private SseEmitter registerEmitter(Long memberId) {

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/alarm/service/EmitterService.java
@@ -46,7 +46,13 @@ public class EmitterService {
         String message = (isMissedAlarms || isAnnouncementChecked || isItemUnlockedChecked)
                 ? "new sse alarm exists"
                 : "new sse alarm doesn't exists";
-
+        
+        // 아이템 잠금 해제를 확인한 것으로 저장
+        if (isItemUnlockedChecked) {
+            user.setIsItemUnlockedChecked(true);
+            userService.saveUser(user);
+        }
+        
         sendToClient(user.getUserId(), AlarmDefaultDataDto.from(!isMissedAlarms, isAnnouncementChecked, isItemUnlockedChecked), message);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/entity/BadgeType.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/entity/BadgeType.java
@@ -6,12 +6,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum BadgeType {
-    READ("열정적인 독자", "완독 수 {0}권 돌파!"),
-    ARCHIVE("꼼꼼한 기록자", "기록카드 수 {0}개 돌파!"),
-    ONELINE("성실한 평가자", "한줄평 수 {0}개 돌파!"),
-    LEVEL("레벨업 마스터", "레벨 {0} 달성!"),
+    READ("열정적인 독자", "완독 수 {0}권 돌파!", "책 {0}권 읽기"),
+    ARCHIVE("꼼꼼한 기록자", "기록 수 {0}개 돌파!", "기록 {0}개 작성하기"),
+    ONELINE("성실한 평가자", "한줄평 수 {0}개 돌파!", "한줄평 {0}개 작성하기"),
+    LEVEL("레벨업 마스터", "레벨 {0} 달성!", "레벨 {0}"),
     ;
 
     private final String title;
     private final String description;
+    private final String modalMessage;
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/User.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/entity/User.java
@@ -38,9 +38,6 @@ public class User extends BaseTimeEntity {
 
     @NotNull
     private Boolean isAnnouncementChecked;
-
-    @NotNull
-    private Boolean isItemUnlockedChecked;
     
     @ColumnDefault("false")
     private boolean isOfficial;
@@ -54,7 +51,6 @@ public class User extends BaseTimeEntity {
         this.role = role;
         this.userStatus = UserStatus.ACTIVE;
         this.isAnnouncementChecked = true;
-        this.isItemUnlockedChecked = true;
         this.isOfficial = isOfficial;
     }
 
@@ -70,9 +66,5 @@ public class User extends BaseTimeEntity {
 
     public void setIsAnnouncementChecked(boolean isAnnouncementChecked) {
         this.isAnnouncementChecked = isAnnouncementChecked;
-    }
-
-    public void setIsItemUnlockedChecked(boolean isItemUnlockedChecked) {
-        this.isItemUnlockedChecked = isItemUnlockedChecked;
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/fcm/FCMService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/fcm/FCMService.java
@@ -4,18 +4,13 @@ package com.mmc.bookduck.global.fcm;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import com.mmc.bookduck.domain.user.entity.User;
-import com.mmc.bookduck.domain.user.repository.UserRepository;
 import com.mmc.bookduck.domain.user.service.UserService;
-import com.mmc.bookduck.global.security.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.text.MessageFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,11 +30,14 @@ public class FCMService {
 
     // 토큰 기반 전송
     public void sendPushMessage(String token, String alarmMessage) {
-        Message message = Message.builder().setNotification(Notification.builder()
-                        .setTitle(alarmMessage)
-                        .setBody("북덕에서 확인하세요.")
-                        .build())
-                .setToken(token)  // 대상 디바이스의 등록 토큰
+        // Data 페이로드 구성
+        Map<String, String> data = new HashMap<>();
+        data.put("title", alarmMessage);
+        data.put("body", "북덕에서 확인하세요."); // 원하는 추가 데이터 포함
+        // Message 생성
+        Message message = Message.builder()
+                .putAllData(data)  // Data 필드에 데이터를 추가
+                .setToken(token)
                 .build();
         try {
             String response = FirebaseMessaging.getInstance().send(message);


### PR DESCRIPTION
# 구현 기능
  - FCM을 data 항목에 전송하도록 수정했습니다.
  - 레벨업과 뱃지 획득, 아이템 획득은 푸시알림이 발생하지 않도록 설정했습니다.
  - subscrive 및 sse 알림 발생시의 응답에서, 레벨업과 뱃지 획득 모달창 데이터도 넘겨주도록 수정했습니다.
  - 아이템 알림이 알림 목록에 표시됨으로 ITEM_UNLOCKED를 AlarmType에 추가했습니다.
  - 아이템 알림이 최초 1회 뜸에 따라 User에서 isItemUnlockedChecked를 삭제하였습니다.
