### PR TITLE
[Feat] 회원탈퇴시 custom책, 폴더 삭제 로직 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/repository/BookInfoRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/repository/BookInfoRepository.java
@@ -26,4 +26,6 @@ public interface BookInfoRepository extends JpaRepository<BookInfo, Long> {
             "ORDER BY COUNT(b) DESC")
     List<BookInfo> findRelatedBooksByBookInfoId(@Param("bookInfoId") Long bookInfoId);
 
+    @Query("SELECT b FROM BookInfo b WHERE b.createdUserId = :userId")
+    List<BookInfo> findCustomBookByCreatedUserId(@Param("userId") Long userId);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
@@ -32,7 +32,7 @@ import com.mmc.bookduck.domain.book.entity.ReadStatus;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.repository.BookInfoRepository;
 import com.mmc.bookduck.domain.book.repository.UserBookRepository;
-import com.mmc.bookduck.domain.friend.service.FriendService;
+import com.mmc.bookduck.domain.friend.repository.FriendRepository;
 import com.mmc.bookduck.domain.oneline.dto.response.OneLineRatingListResponseDto;
 import com.mmc.bookduck.domain.oneline.dto.response.OneLineRatingUnitDto;
 import com.mmc.bookduck.domain.oneline.entity.OneLine;
@@ -77,7 +77,7 @@ public class BookInfoService {
     private final UserService userService;
     private final OneLineRepository oneLineRepository;
     private final S3Service s3Service;
-    private final FriendService friendService;
+    private final FriendRepository friendRepository;
 
     // api 도서 목록 조회
     public BookListResponseDto<BookUnitResponseDto> searchBookList(String keyword, Long page, Long size) {
@@ -342,7 +342,7 @@ public class BookInfoService {
         if(bookInfo.getCreatedUserId().equals(user.getUserId())){ // 내 customBook
             MyRatingOneLineReadStatusDto myRatingOneLine = getMyRatingOneLineReadStatus(bookInfo, user);
             return new CustomBookResponseDto(userBook, myRatingOneLine.myRating(),myRatingOneLine.oneLineId(), myRatingOneLine.myOneLine(), true);
-        }else if(friendService.isFriendWithCurrentUserOrNull(bookInfoCreaterUser)){ //친구 customBook
+        }else if(isFriend(user,bookInfoCreaterUser)){ //친구 customBook
             return new CustomBookResponseDto(userBook, false);
         }else{
             throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST); //내것도 아니고 친구것도 아닌 경우
@@ -492,8 +492,9 @@ public class BookInfoService {
     @Transactional(readOnly = true)
     public UserArchiveResponseDto getAllUserBookArchive(Long bookInfoId, Long userId, Pageable pageable) {
         User bookUser = userService.getActiveUserByUserId(userId);
+        User currentUser = userService.getCurrentUser();
 
-        if(!friendService.isFriendWithCurrentUserOrNull(bookUser)){
+        if(!isFriend(currentUser,bookUser)){
             throw new CustomException(ErrorCode.FRIENDSHIP_REQUIRED);
         }
         BookInfo bookInfo = getBookInfoById(bookInfoId);
@@ -513,6 +514,14 @@ public class BookInfoService {
         List<UserArchiveResponseDto.ArchiveWithoutTitleAuthor> sortedArchiveList = sortByCreatedTime(archiveList);
         Page<UserArchiveResponseDto.ArchiveWithoutTitleAuthor> dtoPage = new PageImpl<>(sortedArchiveList, pageable, sortedArchiveList.size());
         return UserArchiveResponseDto.fromWithoutTitleAuthor(dtoPage);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isFriend(User currentUser, User otherUser){
+        if (currentUser == null) {
+            return false;
+        }
+        return friendRepository.findFriendBetweenUsers(currentUser.getUserId(), otherUser.getUserId()).isPresent();
     }
 
     @Transactional(readOnly = true)
@@ -600,4 +609,15 @@ public class BookInfoService {
         return new BookListResponseDto<>(topSixBooks);
     }
 
+    // 사용자 customBook 삭제
+    public void deleteUserCustomBook(User user) {
+        List<BookInfo> customBookList = bookInfoRepository.findCustomBookByCreatedUserId(user.getUserId());
+        for(BookInfo customBook : customBookList){
+            Optional<UserBook> customUserBook = userBookRepository.findByUserAndBookInfo(user, customBook);
+            if(customUserBook.isPresent()){
+                userBookRepository.delete(customUserBook.get());
+            }
+            bookInfoRepository.delete(customBook);
+        }
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
@@ -518,9 +518,6 @@ public class BookInfoService {
 
     @Transactional(readOnly = true)
     public boolean isFriend(User currentUser, User otherUser){
-        if (currentUser == null) {
-            return false;
-        }
         return friendRepository.findFriendBetweenUsers(currentUser.getUserId(), otherUser.getUserId()).isPresent();
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/repository/FolderRepository.java
@@ -13,4 +13,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     List<Folder> findAllByUserOrderByFolderIdDesc(User user);
 
     boolean existsByFolderNameAndUser(String folderName, User user);
+
+    List<Folder> findAllByUser(User user);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/folder/service/FolderService.java
@@ -295,4 +295,12 @@ public class FolderService {
             return true;
         }
     }
+
+    // 사용자 폴더 삭제
+    public void deleteUserFolder(User user) {
+        List<Folder> folders = folderRepository.findAllByUser(user);
+        for (Folder folder : folders) {
+            deleteFolder(folder.getFolderId());
+        }
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSettingService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSettingService.java
@@ -1,5 +1,7 @@
 package com.mmc.bookduck.domain.user.service;
 
+import com.mmc.bookduck.domain.book.service.BookInfoService;
+import com.mmc.bookduck.domain.folder.service.FolderService;
 import com.mmc.bookduck.domain.user.dto.request.UserNicknameRequestDto;
 import com.mmc.bookduck.domain.user.dto.request.UserSettingUpdateRequestDto;
 import com.mmc.bookduck.domain.user.dto.response.UserNicknameResponseDto;
@@ -30,6 +32,8 @@ public class UserSettingService {
     private final UserSettingRepository userSettingRepository;
     private final RedisService redisService;
     private final CookieUtil cookieUtil;
+    private final FolderService folderService;
+    private final BookInfoService bookInfoService;
 
     @Transactional(readOnly = true)
     public UserSettingInfoResponseDto getUserSettingInfo() {
@@ -84,6 +88,10 @@ public class UserSettingService {
 
     public void deactivate(HttpServletResponse response) {
         User user = userService.getCurrentUser();
+
+        // 폴더 & 커스텀책 삭제
+        folderService.deleteUserFolder(user);
+        bookInfoService.deleteUserCustomBook(user);
 
         String nickname = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 8);
         user.updateNickname(nickname);


### PR DESCRIPTION
# 구현 기능
  - 회원탈퇴 할때, custom책과 폴더(폴더책) 삭제하는 로직 추가했습니다.
  - userSettingService에 folderService와 bookInfoService 의존성 추가하니까 여러 service에 걸쳐서 순환참조가 생겨서 bookInfoService에서 친구인지 확인하는 로직 수정해서 순환참조 생기지 않도록 했습니다.
