### PR TITLE
fix: 프론트 요구사항에 맞춰 통합조회, 수정 uri 수정

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/controller/ArchiveController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/controller/ArchiveController.java
@@ -43,18 +43,18 @@ public class ArchiveController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{archiveId}")
     @Operation(summary = "발췌 및 감상평 통합 조회", description = "발췌와 감상평을 조회합니다.")
-    public ResponseEntity<?> getArchive(@PathVariable("id") final Long id, @RequestParam("type") final ArchiveType archiveType) {
-        ArchiveResponseDto responseDto = archiveService.getArchive(id, archiveType);
+    public ResponseEntity<?> getArchive(@PathVariable("archiveId") final Long archiveId) {
+        ArchiveResponseDto responseDto = archiveService.getArchive(archiveId);
         return ResponseEntity.ok(responseDto);
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/{archiveId}")
     @Operation(summary = "발췌 및 감상평 통합 수정", description = "발췌와 감상평을 수정합니다.(없던 종류의 독서기록을 남기는 것 역시 가능함)")
-    public ResponseEntity<?> updateArchive(@PathVariable("id") final Long id, @RequestParam("type") final ArchiveType archiveType,
+    public ResponseEntity<?> updateArchive(@PathVariable("archiveId") final Long archiveId,
                                            @Valid @RequestBody ArchiveUpdateRequestDto requestDto) {
-        ArchiveResponseDto responseDto = archiveService.updateArchive(id, archiveType, requestDto);
+        ArchiveResponseDto responseDto = archiveService.updateArchive(archiveId, requestDto);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/UserArchiveResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/UserArchiveResponseDto.java
@@ -19,6 +19,7 @@ public record UserArchiveResponseDto(
     public record ArchiveWithType(
             ArchiveType type, // EXCERPT, REVIEW
             Object data, // ExcerptResponseDto, ReviewResponseDto
+            Long archiveId,
             String title,
             String author
     ) {}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -77,8 +77,8 @@ public class ArchiveService {
 
     // 조회
     @Transactional(readOnly = true)
-    public ArchiveResponseDto getArchive(Long id, ArchiveType archiveType) {
-        Archive archive = findArchiveByType(id, archiveType);
+    public ArchiveResponseDto getArchive(Long archiveId) {
+        Archive archive = getArchiveById(archiveId);
         UserBook userBook = getUserBookFromExcerptOrReview(archive);
         // currentUser와 creatorUser 사이의 관계에 따른 response 필터링
         Long currentUserId = userService.getCurrentUser().getUserId();
@@ -118,8 +118,8 @@ public class ArchiveService {
     }
 
     // 수정
-    public ArchiveResponseDto updateArchive(Long id, ArchiveType archiveType, ArchiveUpdateRequestDto requestDto) {
-        Archive archive = findArchiveByType(id, archiveType);
+    public ArchiveResponseDto updateArchive(Long archiveId, ArchiveUpdateRequestDto requestDto) {
+        Archive archive = getArchiveById(archiveId);
         UserBook userBook = getUserBookFromExcerptOrReview(archive);
         // 생성자 검증
         userBookService.validateUserBookOwner(userBook);
@@ -210,9 +210,10 @@ public class ArchiveService {
                 if (!userId.equals(currentUserId) && excerpt.getVisibility() != Visibility.PUBLIC) {
                     continue;
                 }
+                Long archiveId = findArchiveByType(excerpt.getExcerptId(), EXCERPT).getArchiveId();
                 String title = excerpt.getUserBook().getBookInfo().getTitle();
                 String author = excerpt.getUserBook().getBookInfo().getAuthor();
-                archiveList.add(new UserArchiveResponseDto.ArchiveWithType(EXCERPT, ExcerptResponseDto.from(excerpt), title, author));
+                archiveList.add(new UserArchiveResponseDto.ArchiveWithType(EXCERPT, ExcerptResponseDto.from(excerpt), archiveId, title, author));
             }
         }
         // 리뷰 조회
@@ -222,9 +223,10 @@ public class ArchiveService {
                 if (!userId.equals(currentUserId) && review.getVisibility() != Visibility.PUBLIC) {
                     continue;
                 }
+                Long archiveId = findArchiveByType(review.getReviewId(), REVIEW).getArchiveId();
                 String title = review.getUserBook().getBookInfo().getTitle();
                 String author = review.getUserBook().getBookInfo().getAuthor();
-                archiveList.add(new UserArchiveResponseDto.ArchiveWithType(REVIEW, ReviewResponseDto.from(review), title, author));
+                archiveList.add(new UserArchiveResponseDto.ArchiveWithType(REVIEW, ReviewResponseDto.from(review), archiveId,title, author));
             }
         }
         // 데이터 합친 후 최신순 정렬


### PR DESCRIPTION
# 구현 기능
  - 프론트 요청으로 통합조회, 수정 uri를 수정했습니다. (그러나 공유된 링크로 발췌 및 감상평 통합 상세 조회의 경우는 기존 uri인 /archives/share/{id}?type={archiveType}  그대로 사용합니다.) 
  - uri수정에 따라 그전 페이지인 유저 기록 아카이브 조회 응답에 archiveId 추가
  ```
{
    "currentPage": 0,
    "pageSize": 20,
    "totalElements": 6,
    "totalPages": 1,
    "archiveList": [
        {
            "type": "REVIEW",
            "data": {
                "reviewId": 3,
                "reviewTitle": "리뷰 제목 수정했음",
                "reviewContent": "내용",
                "color": "#FFFFFF",
                "visibility": "PRIVATE",
                "createdTime": "2024-12-01T14:51:51.484733",
                "modifiedTime": "2024-12-01T14:54:50.198789"
            },
            "archiveId": 3,
            "title": "작별하지 않는다",
            "author": "한강"
        },
        {
            "type": "EXCERPT",
            "data": {
                "excerptId": 3,
                "excerptContent": "내용을 수정합니다",
                "pageNumber": 123,
                "visibility": "PRIVATE",
                "createdTime": "2024-12-01T14:51:51.414239",
                "modifiedTime": "2024-12-01T14:54:50.188612"
            },
            "archiveId": 3,
            "title": "작별하지 않는다",
            "author": "한강"
        }, ...
}
```

# Resolve
  - #86 
