### PR TITLE
[Feat] Badge, Exp 획득 관련 로직 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -14,11 +14,13 @@ import com.mmc.bookduck.domain.archive.entity.Review;
 import com.mmc.bookduck.domain.archive.repository.ArchiveRepository;
 import com.mmc.bookduck.domain.archive.repository.ExcerptRepository;
 import com.mmc.bookduck.domain.archive.repository.ReviewRepository;
+import com.mmc.bookduck.domain.badge.service.BadgeUnlockService;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.service.UserBookService;
 import com.mmc.bookduck.domain.common.Visibility;
 import com.mmc.bookduck.domain.friend.entity.Friend;
 import com.mmc.bookduck.domain.friend.repository.FriendRepository;
+import com.mmc.bookduck.domain.user.service.UserGrowthService;
 import com.mmc.bookduck.domain.user.service.UserService;
 import com.mmc.bookduck.global.common.PaginatedResponseDto;
 import com.mmc.bookduck.global.exception.CustomException;
@@ -51,6 +53,8 @@ public class ArchiveService {
     private final ExcerptRepository excerptRepository;
     private final ReviewRepository reviewRepository;
     private final FriendRepository friendRepository;
+    private final UserGrowthService userGrowthService;
+    private final BadgeUnlockService badgeUnlockService;
 
     // 생성
     public ArchiveResponseDto createArchive(ArchiveCreateRequestDto requestDto) {
@@ -72,7 +76,14 @@ public class ArchiveService {
                 .orElse(null);
         Archive archive = requestDto.toEntity(excerpt, review);
         archiveRepository.save(archive);
+        checkExpAndBadgeForArchive(userBook);
         return createArchiveResponseDto(archive, excerpt, review, userBook);
+    }
+
+    // 경험치 획득, ARCHIVE 뱃지 unlock 확인
+    public void checkExpAndBadgeForArchive(UserBook userBook) {
+        userGrowthService.gainExpForArchive(userBook);
+        badgeUnlockService.checkAndUnlockBadges(userBook.getUser());
     }
 
     // 조회

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/dto/common/UserActivityDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/dto/common/UserActivityDto.java
@@ -1,6 +1,6 @@
-package com.mmc.bookduck.domain.badge.entity;
+package com.mmc.bookduck.domain.badge.dto.common;
 
-public record UserActivity(
+public record UserActivityDto(
         long readCount,
         long archiveCount,
         long oneLineCount,

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/entity/UserActivity.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/entity/UserActivity.java
@@ -1,0 +1,8 @@
+package com.mmc.bookduck.domain.badge.entity;
+
+public record UserActivity(
+        long readCount,
+        long archiveCount,
+        long oneLineCount,
+        long level
+) {}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class BadgeService {
     private final BadgeRepository badgeRepository;
@@ -28,5 +27,14 @@ public class BadgeService {
     @Transactional(readOnly = true)
     public List<Badge> getAllBadges() {
         return badgeRepository.findAll();
+    }
+
+    // 뱃지 잠금해제 조건을 int로 가져옴
+    public int getBadgeUnlockValue(Badge badge) {
+        try {
+            return Integer.parseInt(badge.getUnlockCondition());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
@@ -1,0 +1,92 @@
+package com.mmc.bookduck.domain.badge.service;
+
+import com.mmc.bookduck.domain.alarm.service.AlarmByTypeService;
+import com.mmc.bookduck.domain.archive.repository.ExcerptRepository;
+import com.mmc.bookduck.domain.archive.repository.ReviewRepository;
+import com.mmc.bookduck.domain.badge.entity.Badge;
+import com.mmc.bookduck.domain.badge.entity.UserActivity;
+import com.mmc.bookduck.domain.badge.entity.UserBadge;
+import com.mmc.bookduck.domain.badge.repository.UserBadgeRepository;
+import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.repository.UserBookRepository;
+import com.mmc.bookduck.domain.oneline.repository.OneLineRepository;
+import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.service.UserGrowthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BadgeUnlockService {
+    private final UserBadgeRepository userBadgeRepository;
+    private final UserBookRepository userBookRepository;
+    private final ReviewRepository reviewRepository;
+    private final ExcerptRepository excerptRepository;
+    private final OneLineRepository oneLineRepository;
+    private final BadgeService badgeService;
+    private final UserGrowthService userGrowthService;
+    private final AlarmByTypeService alarmByTypeService;
+
+    // 유저 활동 가져오기
+    public UserActivity getUserActivity(User user) {
+        // 각 활동 데이터 조회
+        long readCount = userBookRepository.countByUserAndReadStatus(user, ReadStatus.FINISHED);
+        long archiveCount = reviewRepository.countByUser(user) + excerptRepository.countByUser(user);
+        long oneLineCount = oneLineRepository.countAllByUser(user);
+        long level = userGrowthService.getUserGrowthByUserId(user.getUserId()).getLevel();
+
+        // 결과 반환
+        return new UserActivity(readCount, archiveCount, oneLineCount, level);
+    }
+
+    // 뱃지 획득 트리거
+    public void checkAndUnlockBadges(User user) {
+        // 사용자 활동 데이터 가져오기
+        UserActivity activity = getUserActivity(user);
+
+        // 현재 사용자가 이미 보유한 뱃지
+        List<Long> ownedBadgeIds = userBadgeRepository.findAllByUser(user).stream()
+                .map(userBadge -> userBadge.getBadge().getBadgeId())
+                .toList();
+
+        // 전체 뱃지 가져오기
+        List<Badge> allBadges = badgeService.getAllBadges();
+
+        for (Badge badge : allBadges) {
+            if (ownedBadgeIds.contains(badge.getBadgeId())) {
+                continue; // 이미 보유한 뱃지는 스킵
+            }
+
+            // 뱃지 조건 확인
+            boolean isConditionMet = isBadgeConditionMet(badge, activity);
+
+            if (isConditionMet) {
+                // UserBadge 생성 및 저장
+                UserBadge userBadge = UserBadge.builder()
+                        .user(user)
+                        .badge(badge)
+                        .build();
+                userBadgeRepository.save(userBadge);
+
+                // 뱃지 획득 알림 생성
+                alarmByTypeService.createBadgeUnlockedAlarm(user, userBadge);
+            }
+        }
+    }
+
+    // 뱃지 획득조건 충족여부 확인
+    private boolean isBadgeConditionMet(Badge badge, UserActivity activity) {
+        int unlockValue = badgeService.getBadgeUnlockValue(badge);
+
+        return switch (badge.getBadgeType()) {
+            case READ -> activity.readCount() >= unlockValue;
+            case ARCHIVE -> activity.archiveCount() >= unlockValue;
+            case ONELINE -> activity.oneLineCount() >= unlockValue;
+            case LEVEL -> activity.level() >= unlockValue;
+        };
+    }
+}

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
@@ -8,10 +8,14 @@ import com.mmc.bookduck.domain.badge.entity.UserActivity;
 import com.mmc.bookduck.domain.badge.entity.UserBadge;
 import com.mmc.bookduck.domain.badge.repository.UserBadgeRepository;
 import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.repository.UserBookRepository;
 import com.mmc.bookduck.domain.oneline.repository.OneLineRepository;
 import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.repository.UserGrowthRepository;
 import com.mmc.bookduck.domain.user.service.UserGrowthService;
+import com.mmc.bookduck.global.exception.CustomException;
+import com.mmc.bookduck.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +32,7 @@ public class BadgeUnlockService {
     private final ExcerptRepository excerptRepository;
     private final OneLineRepository oneLineRepository;
     private final BadgeService badgeService;
-    private final UserGrowthService userGrowthService;
+    private final UserGrowthRepository userGrowthRepository;
     private final AlarmByTypeService alarmByTypeService;
 
     // 유저 활동 가져오기
@@ -37,7 +41,7 @@ public class BadgeUnlockService {
         long readCount = userBookRepository.countByUserAndReadStatus(user, ReadStatus.FINISHED);
         long archiveCount = reviewRepository.countByUser(user) + excerptRepository.countByUser(user);
         long oneLineCount = oneLineRepository.countAllByUser(user);
-        long level = userGrowthService.getUserGrowthByUser(user).getLevel();
+        long level = userGrowthRepository.findByUser(user).orElseThrow(()-> new CustomException(ErrorCode.USERGROWTH_NOT_FOUND)).getLevel();
 
         // 결과 반환
         return new UserActivity(readCount, archiveCount, oneLineCount, level);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class BadgeUnlockService {
     private final UserBadgeRepository userBadgeRepository;
@@ -34,6 +34,7 @@ public class BadgeUnlockService {
     private final AlarmByTypeService alarmByTypeService;
 
     // 유저 활동 가져오기
+    @Transactional(readOnly = true)
     public UserActivityDto getUserActivity(User user) {
         // 각 활동 데이터 조회
         long readCount = userBookRepository.countByUserAndReadStatus(user, ReadStatus.FINISHED);
@@ -81,6 +82,7 @@ public class BadgeUnlockService {
     }
 
     // 뱃지 획득조건 충족여부 확인
+    @Transactional(readOnly = true)
     private boolean isBadgeConditionMet(Badge badge, UserActivityDto activity) {
         int unlockValue = badgeService.getBadgeUnlockValue(badge);
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/BadgeUnlockService.java
@@ -37,7 +37,7 @@ public class BadgeUnlockService {
         long readCount = userBookRepository.countByUserAndReadStatus(user, ReadStatus.FINISHED);
         long archiveCount = reviewRepository.countByUser(user) + excerptRepository.countByUser(user);
         long oneLineCount = oneLineRepository.countAllByUser(user);
-        long level = userGrowthService.getUserGrowthByUserId(user.getUserId()).getLevel();
+        long level = userGrowthService.getUserGrowthByUser(user).getLevel();
 
         // 결과 반환
         return new UserActivity(readCount, archiveCount, oneLineCount, level);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/UserBadgeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/UserBadgeService.java
@@ -6,7 +6,7 @@ import com.mmc.bookduck.domain.badge.entity.Badge;
 import com.mmc.bookduck.domain.badge.entity.BadgeType;
 import com.mmc.bookduck.domain.badge.entity.UserBadge;
 import com.mmc.bookduck.domain.badge.repository.UserBadgeRepository;
-import com.mmc.bookduck.domain.badge.entity.UserActivity;
+import com.mmc.bookduck.domain.badge.dto.common.UserActivityDto;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +40,7 @@ public class UserBadgeService {
                 .collect(Collectors.toMap(badge -> badge.getBadge().getBadgeId(), badge -> badge));
 
         // 사용자 상태 조회
-        UserActivity userActivity = badgeUnlockService.getUserActivity(user);
+        UserActivityDto userActivityDto = badgeUnlockService.getUserActivity(user);
 
         // 모든 뱃지와 사용자 상태를 결합한 리스트 생성
         List<UserBadgeUnitDto> allBadgesWithOwnership = allBadges.stream()
@@ -56,10 +56,10 @@ public class UserBadgeService {
                 .collect(Collectors.groupingBy(UserBadgeUnitDto::badgeType));
 
         return new UserBadgeListResponseDto(
-                userActivity.readCount(),
-                userActivity.archiveCount(),
-                userActivity.oneLineCount(),
-                userActivity.level(),
+                userActivityDto.readCount(),
+                userActivityDto.archiveCount(),
+                userActivityDto.oneLineCount(),
+                userActivityDto.level(),
                 badgesByType.getOrDefault(BadgeType.READ, List.of()),
                 badgesByType.getOrDefault(BadgeType.ARCHIVE, List.of()),
                 badgesByType.getOrDefault(BadgeType.ONELINE, List.of()),

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/UserBadgeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/badge/service/UserBadgeService.java
@@ -1,18 +1,13 @@
 package com.mmc.bookduck.domain.badge.service;
 
-import com.mmc.bookduck.domain.alarm.service.AlarmByTypeService;
-import com.mmc.bookduck.domain.archive.repository.ExcerptRepository;
-import com.mmc.bookduck.domain.archive.repository.ReviewRepository;
 import com.mmc.bookduck.domain.badge.dto.common.UserBadgeUnitDto;
 import com.mmc.bookduck.domain.badge.dto.response.UserBadgeListResponseDto;
 import com.mmc.bookduck.domain.badge.entity.Badge;
 import com.mmc.bookduck.domain.badge.entity.BadgeType;
 import com.mmc.bookduck.domain.badge.entity.UserBadge;
 import com.mmc.bookduck.domain.badge.repository.UserBadgeRepository;
-import com.mmc.bookduck.domain.book.service.UserBookService;
-import com.mmc.bookduck.domain.oneline.repository.OneLineRepository;
+import com.mmc.bookduck.domain.badge.entity.UserActivity;
 import com.mmc.bookduck.domain.user.entity.User;
-import com.mmc.bookduck.domain.user.service.UserGrowthService;
 import com.mmc.bookduck.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,14 +23,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class UserBadgeService {
     private final UserBadgeRepository userBadgeRepository;
-    private final OneLineRepository oneLineRepository;
-    private final ReviewRepository reviewRepository;
-    private final ExcerptRepository excerptRepository;
     private final UserService userService;
     private final BadgeService badgeService;
-    private final UserBookService userBookService;
-    private final UserGrowthService userGrowthService;
-    private final AlarmByTypeService alarmByTypeService;
+    private final BadgeUnlockService badgeUnlockService;
 
     @Transactional(readOnly = true)
     public UserBadgeListResponseDto getCurrentUserBadges() {
@@ -49,48 +39,32 @@ public class UserBadgeService {
         Map<Long, UserBadge> userBadgeMap = uniqueUserBadges.stream()
                 .collect(Collectors.toMap(badge -> badge.getBadge().getBadgeId(), badge -> badge));
 
-        // 모든 뱃지와 isOwned를 결합한 리스트 생성
+        // 사용자 상태 조회
+        UserActivity userActivity = badgeUnlockService.getUserActivity(user);
+
+        // 모든 뱃지와 사용자 상태를 결합한 리스트 생성
         List<UserBadgeUnitDto> allBadgesWithOwnership = allBadges.stream()
-                .map(badge -> UserBadgeUnitDto.from(badge, userBadgeMap.get(badge.getBadgeId()), getBadgeUnlockValue(badge)))
-                .collect(Collectors.toList());
+                .map(badge -> UserBadgeUnitDto.from(
+                        badge,
+                        userBadgeMap.get(badge.getBadgeId()),
+                        badgeService.getBadgeUnlockValue(badge)
+                ))
+                .toList();
 
-        // BadgeType별로 뱃지 리스트 나누기
-        List<UserBadgeUnitDto> readBadgeList = filterByBadgeType(allBadgesWithOwnership, BadgeType.READ);
-        List<UserBadgeUnitDto> archiveBadgeList = filterByBadgeType(allBadgesWithOwnership, BadgeType.ARCHIVE);
-        List<UserBadgeUnitDto> oneLineBadgeList = filterByBadgeType(allBadgesWithOwnership, BadgeType.ONELINE);
-        List<UserBadgeUnitDto> levelBadgeList = filterByBadgeType(allBadgesWithOwnership, BadgeType.LEVEL);
-
-        // 각 분야별 사용자 상태 가져오기
-        long currentReadCount = userBookService.countFinishedUserBooksByUser(user);
-        long currentArchiveCount = reviewRepository.countByUser(user) + excerptRepository.countByUser(user);
-        long currentOneLineCount = oneLineRepository.countAllByUser(user);
-        long currentLevel = userGrowthService.getUserGrowthByUserId(user.getUserId()).getLevel();
+        // BadgeType별로 필터링
+        Map<BadgeType, List<UserBadgeUnitDto>> badgesByType = allBadgesWithOwnership.stream()
+                .collect(Collectors.groupingBy(UserBadgeUnitDto::badgeType));
 
         return new UserBadgeListResponseDto(
-                currentReadCount,
-                currentArchiveCount,
-                currentOneLineCount,
-                currentLevel,
-                readBadgeList,
-                archiveBadgeList,
-                oneLineBadgeList,
-                levelBadgeList
+                userActivity.readCount(),
+                userActivity.archiveCount(),
+                userActivity.oneLineCount(),
+                userActivity.level(),
+                badgesByType.getOrDefault(BadgeType.READ, List.of()),
+                badgesByType.getOrDefault(BadgeType.ARCHIVE, List.of()),
+                badgesByType.getOrDefault(BadgeType.ONELINE, List.of()),
+                badgesByType.getOrDefault(BadgeType.LEVEL, List.of())
         );
-    }
-
-    // 뱃지 잠금해제 조건을 int로 가져옴
-    private int getBadgeUnlockValue(Badge badge) {
-        try {
-            return Integer.parseInt(badge.getUnlockCondition());
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
-
-    private List<UserBadgeUnitDto> filterByBadgeType(List<UserBadgeUnitDto> allBadgesWithOwnership, BadgeType badgeType) {
-        return allBadgesWithOwnership.stream()
-                .filter(dto -> dto.badgeType().equals(badgeType))
-                .collect(Collectors.toList());
     }
 
     public List<UserBadge> deleteDuplicateUserBadges(List<UserBadge> userBadges) {
@@ -117,53 +91,5 @@ public class UserBadgeService {
 
     public void deleteUserBadgesByUser(User user) {
         userBadgeRepository.deleteAllByUser(user);
-    }
-
-
-    public void checkAndUnlockBadges(User user) {
-        // 사용자의 상태 가져오기
-        long currentReadCount = userBookService.countFinishedUserBooksByUser(user);
-        long currentArchiveCount = reviewRepository.countByUser(user) + excerptRepository.countByUser(user);
-        long currentOneLineCount = oneLineRepository.countAllByUser(user);
-        long currentLevel = userGrowthService.getUserGrowthByUserId(user.getUserId()).getLevel();
-
-        // 현재 사용자가 이미 보유한 뱃지
-        List<Long> ownedBadgeIds = userBadgeRepository.findAllByUser(user).stream()
-                .map(userBadge -> userBadge.getBadge().getBadgeId())
-                .toList();
-
-        // 전체 뱃지 가져오기
-        List<Badge> allBadges = badgeService.getAllBadges();
-
-        for (Badge badge : allBadges) {
-            if (ownedBadgeIds.contains(badge.getBadgeId())) {
-                continue; // 이미 보유한 뱃지는 스킵
-            }
-
-            // 조건 확인
-            boolean isConditionMet = isBadgeConditionMet(badge, currentReadCount, currentArchiveCount, currentOneLineCount, currentLevel);
-
-            if (isConditionMet) {
-                // UserBadge 생성
-                UserBadge userBadge = UserBadge.builder()
-                        .user(user)
-                        .badge(badge)
-                        .build();
-                userBadgeRepository.save(userBadge);
-                // 뱃지 알림 생성
-                alarmByTypeService.createBadgeUnlockedAlarm(user, userBadge);
-            }
-        }
-    }
-
-    private boolean isBadgeConditionMet(Badge badge, long currentReadCount, long currentArchiveCount, long currentOneLineCount, long currentLevel) {
-        int unlockValue = getBadgeUnlockValue(badge);
-
-        return switch (badge.getBadgeType()) {
-            case READ -> currentReadCount >= unlockValue;
-            case ARCHIVE -> currentArchiveCount >= unlockValue;
-            case ONELINE -> currentOneLineCount >= unlockValue;
-            case LEVEL -> currentLevel >= unlockValue;
-        };
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
@@ -151,8 +151,8 @@ public class UserBookService {
             throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
         }
         userBook.changeReadStatus(ReadStatus.valueOf(status));
-
-        badgeUnlockService.checkAndUnlockBadges(user);
+        // 경험치, 뱃지
+        bookInfoService.checkExpAndBadge(user, userBook);
         return convertToUserBookResponseDto(userBook);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/UserBookService.java
@@ -44,7 +44,6 @@ public class UserBookService {
     private final UserService userService;
     private final ExcerptRepository excerptRepository;
     private final ReviewRepository reviewRepository;
-    private final BadgeUnlockService badgeUnlockService;
 
     //customBook 추가
     public UserBook createCustomBookEntity(CustomBookRequestDto requestDto) {
@@ -152,7 +151,7 @@ public class UserBookService {
         }
         userBook.changeReadStatus(ReadStatus.valueOf(status));
         // 경험치, 뱃지
-        bookInfoService.checkExpAndBadge(user, userBook);
+        bookInfoService.checkExpAndBadgeForFinishedBook(userBook);
         return convertToUserBookResponseDto(userBook);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/service/OneLineService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/service/OneLineService.java
@@ -1,5 +1,6 @@
 package com.mmc.bookduck.domain.oneline.service;
 
+import com.mmc.bookduck.domain.badge.service.UserBadgeService;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.service.UserBookService;
 import com.mmc.bookduck.domain.homecard.dto.common.OneLineRatingWithBookInfoUnitDto;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/service/OneLineService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/oneline/service/OneLineService.java
@@ -1,6 +1,6 @@
 package com.mmc.bookduck.domain.oneline.service;
 
-import com.mmc.bookduck.domain.badge.service.UserBadgeService;
+import com.mmc.bookduck.domain.badge.service.BadgeUnlockService;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.service.UserBookService;
 import com.mmc.bookduck.domain.homecard.dto.common.OneLineRatingWithBookInfoUnitDto;
@@ -9,6 +9,7 @@ import com.mmc.bookduck.domain.oneline.dto.request.OneLineUpdateRequestDto;
 import com.mmc.bookduck.domain.oneline.entity.OneLine;
 import com.mmc.bookduck.domain.oneline.repository.OneLineRepository;
 import com.mmc.bookduck.domain.user.entity.User;
+import com.mmc.bookduck.domain.user.service.UserGrowthService;
 import com.mmc.bookduck.domain.user.service.UserService;
 import com.mmc.bookduck.global.common.PaginatedResponseDto;
 import com.mmc.bookduck.global.exception.CustomException;
@@ -28,6 +29,8 @@ public class OneLineService {
     private final OneLineRepository oneLineRepository;
     private final UserService userService;
     private final UserBookService userBookService;
+    private final BadgeUnlockService badgeUnlockService;
+    private final UserGrowthService userGrowthService;
 
     // 생성
     public OneLine createOneLine(OneLineCreateRequestDto requestDto) {
@@ -35,7 +38,14 @@ public class OneLineService {
         UserBook userBook = userBookService.getUserBookById(requestDto.userBookId());
         userBookService.validateUserBookOwner(userBook);
         OneLine oneLine = requestDto.toEntity(user, userBook);
+        checkExpAndBadgeForOneLine(userBook);
         return oneLineRepository.save(oneLine);
+    }
+
+    // 경험치 획득, ONELINE 뱃지 unlock 확인
+    public void checkExpAndBadgeForOneLine(UserBook userBook) {
+        userGrowthService.gainExpForOneLine(userBook);
+        badgeUnlockService.checkAndUnlockBadges(userBook.getUser());
     }
 
     // 수정

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserGrowthService.java
@@ -102,6 +102,7 @@ public class UserGrowthService {
         boolean isLevelUp = userGrowth.gainExp(expToAdd);
         if (isLevelUp) {
             alarmByTypeService.createLevelUpAlarm(user, userGrowth.getLevel());
+            // LEVELUP 뱃지 unlock 확인
             badgeUnlockService.checkAndUnlockBadges(user);
         }
         userGrowthRepository.save(userGrowth);


### PR DESCRIPTION
# 구현 기능
  - 뱃지 획득 로직 확인을 위해 BadgeUnlockService와 UserActivityDto를 생성하여 사용했습니다.
  - 뱃지 획득과 경험치 획득 로직을 보완하고 ArchiveService, BookInfoService, UserBookService, OneLineService, UserGrowthService등에 위치시켰습니다.