### PR TITLE
[Hotfix] 기록 상세조회 페이지 응답에 isCustom 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/ArchiveResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/dto/response/ArchiveResponseDto.java
@@ -8,11 +8,12 @@ public record ArchiveResponseDto(
         ExcerptResponseDto excerpt,
         ReviewResponseDto review,
         Long bookInfoId,
+        Boolean isCustom,
         String title,
         String author,
         String imgPath
 ) {
-    public static ArchiveResponseDto from(Archive archive, Long creatorUserId, ExcerptResponseDto excerpt, ReviewResponseDto review, Long bookInfoId, String title, String author, String imgPath) {
-        return new ArchiveResponseDto(archive.getArchiveId(), creatorUserId, excerpt, review, bookInfoId, title, author, imgPath);
+    public static ArchiveResponseDto from(Archive archive, Long creatorUserId, ExcerptResponseDto excerpt, ReviewResponseDto review, Long bookInfoId, boolean isCustom, String title, String author, String imgPath) {
+        return new ArchiveResponseDto(archive.getArchiveId(), creatorUserId, excerpt, review, bookInfoId, isCustom, title, author, imgPath);
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/archive/service/ArchiveService.java
@@ -308,6 +308,7 @@ public class ArchiveService {
     public ArchiveResponseDto createArchiveResponseDto(Archive archive, Excerpt excerpt, Review review, UserBook userBook) {
         Long creatorUserId = userBook.getUser().getUserId();
         Long bookInfoId = userBook.getBookInfo().getBookInfoId();
+        boolean isCustom = userBook.getBookInfo().getCreatedUserId() != null;
         String title = userBook.getBookInfo().getTitle();
         String author = userBook.getBookInfo().getAuthor();
         String imgPath = userBook.getBookInfo().getImgPath();
@@ -317,6 +318,7 @@ public class ArchiveService {
                 excerpt != null ? ExcerptResponseDto.from(excerpt) : null,
                 review != null ? ReviewResponseDto.from(review) : null,
                 bookInfoId,
+                isCustom,
                 title,
                 author,
                 imgPath


### PR DESCRIPTION
# 구현 기능
  - 기록 상세조회 페이지 응답에 isCustom 추가하였습니다. 

# 구현 상태 (선택)
  - img, gif, video...
  - 혹은 내용 정리

# Resolve
  - #86 
