### PR TITLE
[Hotfix] 탈퇴한 유저의 한줄평에도 좋아요 가능하도록 수정

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/onelineLike/service/OneLineLikeService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/onelineLike/service/OneLineLikeService.java
@@ -28,15 +28,16 @@ public class OneLineLikeService {
     public void createOneLineLike(Long oneLineId) {
         OneLine oneLine = oneLineService.getOneLineById(oneLineId);
         User currentUser = userService.getCurrentUser();
+        User oneLineCreator = userService.getActiveUserByUserId(oneLine.getUser().getUserId());
         Optional<OneLineLike> existingLike = oneLineLikeRepository.findByOneLineAndUser(oneLine, currentUser);
         if (existingLike.isPresent()) {
             throw new CustomException(ErrorCode.ONELINELIKE_ALREADY_EXISTS);
         }
         OneLineLike oneLineLike = new OneLineLike(oneLine, currentUser);
         oneLine.addOneLineLike(oneLineLike);
-        // 타 사용자일 떄만 알림 전송
-        if (!currentUser.equals(oneLine.getUser()))
-            alarmByTypeService.createOneLineLikeAlarm(currentUser, oneLine.getUser(), oneLine.getUserBook().getBookInfo());
+        // 타 사용자이고 ACTIVE 상태일 때만 알림 전송
+        if (!currentUser.equals(oneLineCreator))
+            alarmByTypeService.createOneLineLikeAlarm(currentUser, oneLineCreator, oneLine.getUserBook().getBookInfo());
         oneLineLikeRepository.save(oneLineLike);
     }
 


### PR DESCRIPTION
# 구현 기능
  - 탈퇴한 유저의 한줄평에도 좋아요 가능하도록 수정하였습니다. 기존에는 알림보내는 것 때문에 에러가 났습니다.

# 구현 상태 (선택)
  - img, gif, video...
  - 혹은 내용 정리

# Resolve
  - #86 