### PR TITLE
[Feat] Google Books API 호출에 대한 Redis 캐싱 추가, Key Prefix 전략 추가

### DIFF
--- a/bookduck/build.gradle
+++ b/bookduck/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.6'
 }
 
+compileJava {
+	options.compilerArgs << '-parameters'
+}
+
 group = 'com.mmc'
 version = '0.0.1-SNAPSHOT'
 

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/auth/service/AuthService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/auth/service/AuthService.java
@@ -5,7 +5,7 @@ import com.mmc.bookduck.global.exception.CustomTokenException;
 import com.mmc.bookduck.global.exception.ErrorCode;
 import com.mmc.bookduck.global.security.CookieUtil;
 import com.mmc.bookduck.global.security.JwtUtil;
-import com.mmc.bookduck.global.security.RedisService;
+import com.mmc.bookduck.global.redis.RedisService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,16 +37,16 @@ public class AuthService {
         jwtUtil.validateRefreshToken(refreshToken);
         Claims claims = jwtUtil.getRefreshTokenClaims(refreshToken);
         String email = claims.getSubject();
-
+        String redisKey = "auth:refresh_token:" + email;
         // Redis에 저장된 리프레시 토큰과 일치하는지 확인
-        Object storedRefreshToken = redisService.getValues(email);
+        Object storedRefreshToken = redisService.getValues(redisKey);
 
         if (storedRefreshToken == null || !storedRefreshToken.toString().equals(refreshToken)) {
             throw new CustomTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         // 기존 리프레시 토큰 삭제
-        redisService.deleteValues(email);
+        redisService.deleteValues(redisKey);
 
         // 새 액세스 토큰 및 리프레시 토큰 생성
         Authentication authentication = new UsernamePasswordAuthenticationToken(email, null, Collections.singletonList(new SimpleGrantedAuthority(claims.get("role").toString())));

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSettingService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserSettingService.java
@@ -1,10 +1,5 @@
 package com.mmc.bookduck.domain.user.service;
 
-import com.mmc.bookduck.domain.badge.service.UserBadgeService;
-import com.mmc.bookduck.domain.book.service.BookInfoService;
-import com.mmc.bookduck.domain.folder.service.FolderService;
-import com.mmc.bookduck.domain.homecard.service.HomeCardService;
-import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.dto.request.UserNicknameRequestDto;
 import com.mmc.bookduck.domain.user.dto.request.UserSettingUpdateRequestDto;
 import com.mmc.bookduck.domain.user.dto.response.UserNicknameResponseDto;
@@ -12,19 +7,15 @@ import com.mmc.bookduck.domain.user.dto.response.UserSettingInfoResponseDto;
 import com.mmc.bookduck.domain.user.dto.response.UserNicknameAvailabilityResponseDto;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.user.entity.UserSetting;
-import com.mmc.bookduck.domain.user.entity.UserStatus;
 import com.mmc.bookduck.domain.user.repository.UserSettingRepository;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
-import com.mmc.bookduck.global.security.CookieUtil;
-import com.mmc.bookduck.global.security.RedisService;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Consumer;
 
 @Service
@@ -67,9 +58,10 @@ public class UserSettingService {
         User user = userService.getCurrentUser();
         if (user.getNickname().equals(nickname))
             return;
-        if (!userService.existsByNickname(nickname)) {
-            user.updateNickname(nickname); // 트랜잭션 커밋 시 자동 저장
-        } else {
+
+        try {
+            user.updateNickname(nickname); // dirty checking으로 트랜잭션 커밋 시 flush
+        } catch (DataIntegrityViolationException e) {
             throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
         }
     }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserWithdrawService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/user/service/UserWithdrawService.java
@@ -10,7 +10,7 @@ import com.mmc.bookduck.domain.homecard.service.HomeCardService;
 import com.mmc.bookduck.domain.item.service.UserItemService;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.global.security.CookieUtil;
-import com.mmc.bookduck.global.security.RedisService;
+import com.mmc.bookduck.global.redis.RedisService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -59,7 +59,8 @@ public class UserWithdrawService {
         user.clearUserData();;
         userService.saveUser(user);
 
-        redisService.deleteValues(user.getEmail());
+        String redisKey = "auth:refresh_token:" + user.getEmail();
+        redisService.deleteValues(redisKey);
         cookieUtil.deleteCookie(response, "refreshToken");
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -97,7 +97,7 @@ public enum ErrorCode {
 
     // 500 Internal Server Error
     // 외부 API 사용 도중 에러
-    REDIS_CONNECTION_ERROR(500, "서버에서 Redis 연결 중 문제가 발생했습니다."),
+    REDIS_ERROR(500, "서버에서 Redis 사용 중 문제가 발생했습니다."),
     EXTERNAL_API_ERROR(500, "외부 API 사용 중 문제가 발생했습니다."),
     UPLOAD_FAIL_TO_GOOGLE(500, "Google Storage에 업로드하지 못했습니다."),
     UPLOAD_FAIL_TO_S3(500, "S3에 업로드하지 못했습니다."),

--- a/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
@@ -43,8 +43,8 @@ public class GoogleBooksApiService {
             // API GET 요청
             ResponseEntity<String> apiResponse = restTemplate.exchange(url, HttpMethod.GET, null, String.class);
             String result = apiResponse.getBody();
-            // 6시간 캐싱
-            redisService.setValuesWithTimeout(cacheKey, result, Duration.ofHours(6));
+            // 12시간 캐싱
+            redisService.setValuesWithTimeout(cacheKey, result, Duration.ofHours(12));
             return result;
         } catch (RedisException e) {
             throw new CustomException(ErrorCode.REDIS_ERROR);

--- a/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
@@ -37,11 +37,8 @@ public class GoogleBooksApiService {
         }
         try {
             // log.info("redis cache miss");
-            String encodedKeyword = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
-            String url = "https://www.googleapis.com/books/v1/volumes?q=" + encodedKeyword
-                    + "&startIndex=" + (page * size)
-                    + "&maxResults=" + size
-                    + "&key=" + apiKey;
+            String url = "https://www.googleapis.com/books/v1/volumes?q=" + keyword + "&startIndex=" + (page * size)
+                    + "&maxResults=" + size + "&key=" + apiKey;
 
             // API GET 요청
             ResponseEntity<String> apiResponse = restTemplate.exchange(url, HttpMethod.GET, null, String.class);

--- a/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/google/GoogleBooksApiService.java
@@ -2,18 +2,26 @@ package com.mmc.bookduck.global.google;
 
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
+import com.mmc.bookduck.global.redis.RedisService;
+import io.lettuce.core.RedisException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GoogleBooksApiService {
 
+    private final RedisService redisService;
     RestTemplate restTemplate = new RestTemplate();
 
     @Value("${google.books.api.key}")
@@ -21,13 +29,28 @@ public class GoogleBooksApiService {
 
     // 목록 검색
     public String searchBookList(String keyword, Long page, Long size) {
+        String cacheKey = "googlebooks:search_cache:" + keyword;
+        Object cached = redisService.getValues(cacheKey);
+        if (cached != null) {
+            // log.info("redis cache hit");
+            return cached.toString();
+        }
         try {
-            String url = "https://www.googleapis.com/books/v1/volumes?q=" + keyword + "&startIndex=" + (page * size)
-                    + "&maxResults=" + size + "&key=" + apiKey;
+            // log.info("redis cache miss");
+            String encodedKeyword = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
+            String url = "https://www.googleapis.com/books/v1/volumes?q=" + encodedKeyword
+                    + "&startIndex=" + (page * size)
+                    + "&maxResults=" + size
+                    + "&key=" + apiKey;
 
             // API GET 요청
             ResponseEntity<String> apiResponse = restTemplate.exchange(url, HttpMethod.GET, null, String.class);
-            return apiResponse.getBody();
+            String result = apiResponse.getBody();
+            // 6시간 캐싱
+            redisService.setValuesWithTimeout(cacheKey, result, Duration.ofHours(6));
+            return result;
+        } catch (RedisException e) {
+            throw new CustomException(ErrorCode.REDIS_ERROR);
         } catch (Exception e) {
             throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
         }

--- a/bookduck/src/main/java/com/mmc/bookduck/global/redis/RedisService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/redis/RedisService.java
@@ -1,4 +1,4 @@
-package com.mmc.bookduck.global.security;
+package com.mmc.bookduck.global.redis;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/bookduck/src/main/java/com/mmc/bookduck/global/security/CustomLogoutHandler.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/security/CustomLogoutHandler.java
@@ -1,6 +1,7 @@
 package com.mmc.bookduck.global.security;
 
 import com.mmc.bookduck.global.exception.ErrorCode;
+import com.mmc.bookduck.global.redis.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,8 @@ public class CustomLogoutHandler implements LogoutHandler {
 
                 try {
                     // 리프레시 토큰을 Redis에서 삭제 (authentication.getName()인 email을 key로 찾음)
-                    redisService.deleteValues(authentication.getName());
+                    String redisKey = "auth:refresh_token:" + authentication.getName();
+                    redisService.deleteValues(redisKey);
                     // 리프레시 토큰 쿠키 삭제
                 } catch (RedisConnectionFailureException e) {
                     log.error("Redis 연결에 실패했습니다.");

--- a/bookduck/src/main/java/com/mmc/bookduck/global/security/JwtUtil.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/security/JwtUtil.java
@@ -2,6 +2,7 @@ package com.mmc.bookduck.global.security;
 
 import com.mmc.bookduck.global.exception.ErrorCode;
 import com.mmc.bookduck.global.exception.CustomTokenException;
+import com.mmc.bookduck.global.redis.RedisService;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -44,7 +45,8 @@ public class JwtUtil {
         String refreshToken = generateToken(authentication, refreshKey, REFRESH_TOKEN_EXPIRE_TIME);
 
         // 리프레시 토큰을 redis에 저장
-        redisService.setValuesWithTimeout(authentication.getName(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
+        String redisKey = "auth:refresh_token:" + authentication.getName();
+        redisService.setValuesWithTimeout(redisKey, refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
         return refreshToken;
     }
 


### PR DESCRIPTION
# 구현 기능
  - feat: Google Books API 검색 결과 캐시 활용 개발
    - 글 정리: https://hereishyun.tistory.com/208
  - fix: Java Compiler args에 -parameters 추가
    - Spring 3.2 arg0, arg1 에러 해결 (컴파일러가 자동으로 바이트코드를 파싱해 매개변수 이름을 추론하려고 하지 않는 것)
  - refactor: redis에 리프레시 토큰 저장 시 key prefix 적용
    - `[서비스명 또는 도메인]:[기능명]:[식별자]`
    - 리프레시 토큰: auth:refresh_token:{이메일} // 만료 시간: 7일
    - Google Books API 검색 결과: googlebooks:search_cache:{키워드} // 만료 시간: 12시간
  - refactor: UserSettingsService에서 유저 닉네임 변경시 DB 조회 대신 nickname UNIQUE인 점 활용
    - nickname의 고유성은 변경 가능성 낮은 로직, 조회 대신 JPA DataIntegrityViolationException 에러 핸들링으로 성능 향상
  - RedisService 디렉터리 이동
