### PR TITLE
[FEAT] 클럽 생성/가입 시 UserBook 자동 생성 (중복 생성 x)

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/book/service/BookInfoService.java
@@ -332,14 +332,11 @@ public class BookInfoService {
         User bookInfoCreaterUser = userService.getActiveUserByUserId(bookInfo.getCreatedUserId());
         UserBook userBook = getUserBookByUserAndBookInfo(bookInfo, bookInfoCreaterUser);
 
-        if(bookInfo.getCreatedUserId().equals(user.getUserId())){ // 내 customBook
+        if(bookInfo.getCreatedUserId().equals(user.getUserId())) { // 내 customBook
             MyRatingOneLineReadStatusDto myRatingOneLine = getMyRatingOneLineReadStatus(bookInfo, user);
             return new CustomBookResponseDto(userBook, myRatingOneLine.myRating(),myRatingOneLine.oneLineId(), myRatingOneLine.myOneLine(), true);
-        }else if(isFriend(user,bookInfoCreaterUser)){ //친구 customBook
-            return new CustomBookResponseDto(userBook, false);
-        }else{
-            throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST); //내것도 아니고 친구것도 아닌 경우
         }
+        return new CustomBookResponseDto(userBook, false); // 다른 유저가 customBook 보는 것 가능
     }
 
     @Transactional(readOnly = true)

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/dto/common/ClubBookInfoDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/dto/common/ClubBookInfoDto.java
@@ -9,7 +9,8 @@ public record ClubBookInfoDto (
         @Schema(description = "책 정보 ID") Long bookInfoId,
         @Schema(description = "책 표지 이미지 경로") String bookImgPath,
         @Schema(description = "책 제목") String bookTitle,
-        @Schema(description = "책 저자") String bookAuthor
+        @Schema(description = "책 저자") String bookAuthor,
+        @Schema(description = "커스텀책 여부") Boolean isCustom
 ) {
     public static ClubBookInfoDto from(BookInfo bookInfo) {
         return ClubBookInfoDto.builder()
@@ -17,6 +18,7 @@ public record ClubBookInfoDto (
                 .bookImgPath(bookInfo.getImgPath())
                 .bookTitle(bookInfo.getTitle())
                 .bookAuthor(bookInfo.getAuthor())
+                .isCustom(bookInfo.getCreatedUserId()!=null)
                 .build();
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
@@ -4,7 +4,6 @@ import com.mmc.bookduck.domain.book.entity.BookInfo;
 import com.mmc.bookduck.domain.book.entity.ReadStatus;
 import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.repository.UserBookRepository;
-import com.mmc.bookduck.domain.book.service.BookInfoService;
 import com.mmc.bookduck.domain.club.dto.common.ClubMemberRoleInfo;
 import com.mmc.bookduck.domain.club.entity.Club;
 import com.mmc.bookduck.domain.club.entity.ClubMember;

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
@@ -1,5 +1,10 @@
 package com.mmc.bookduck.domain.club.service;
 
+import com.mmc.bookduck.domain.book.entity.BookInfo;
+import com.mmc.bookduck.domain.book.entity.ReadStatus;
+import com.mmc.bookduck.domain.book.entity.UserBook;
+import com.mmc.bookduck.domain.book.repository.UserBookRepository;
+import com.mmc.bookduck.domain.book.service.BookInfoService;
 import com.mmc.bookduck.domain.club.dto.common.ClubMemberRoleInfo;
 import com.mmc.bookduck.domain.club.entity.Club;
 import com.mmc.bookduck.domain.club.entity.ClubMember;
@@ -13,30 +18,43 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ClubMemberService {
     private final ClubMemberRepository clubMemberRepository;
+    private final UserBookRepository userBookRepository;
 
     // 클럽 멤버 생성
-    private ClubMember createClubMember(Club club, User user, ClubMemberRole role) {
+    private ClubMember createClubMemberAndAddUserBook(Club club, BookInfo bookInfo, User user, ClubMemberRole role) {
         ClubMember clubMember = ClubMember.builder()
                 .club(club)
                 .user(user)
                 .clubMemberRole(role)
                 .build();
+        Optional<UserBook> existingUserBook = userBookRepository.findByUserAndBookInfo(user, bookInfo);
+        if (existingUserBook.isEmpty()) {
+            UserBook userBook = new UserBook(ReadStatus.READING, user, bookInfo);
+            userBookRepository.save(userBook);
+        } else {
+            UserBook userBook = existingUserBook.get();
+            if (userBook.getReadStatus() == ReadStatus.NOT_STARTED) {
+                userBook.changeReadStatus(ReadStatus.READING);
+                userBookRepository.save(userBook);
+            }
+        }
         return clubMemberRepository.save(clubMember);
     }
 
     // 클럽 리더 생성
-    public ClubMember createClubLeader(Club club, User user) {
-        return createClubMember(club, user, ClubMemberRole.LEADER);
+    public ClubMember createClubLeader(Club club, BookInfo bookInfo, User user) {
+        return createClubMemberAndAddUserBook(club, bookInfo, user, ClubMemberRole.LEADER);
     }
 
     // 클럽 가입하기
-    public ClubMember joinToClub(Club club, User user) {
+    public ClubMember joinToClub(Club club, BookInfo bookInfo, User user) {
         // 이미 가입한 멤버인지 확인
         boolean alreadyJoined = clubMemberRepository.existsByClubAndUser(club, user);
         if (alreadyJoined) {
@@ -48,7 +66,7 @@ public class ClubMemberService {
             throw new CustomException(ErrorCode.CLUB_FULL);
         }
         // 클럽 가입
-        return createClubMember(club, user, ClubMemberRole.MEMBER);
+        return createClubMemberAndAddUserBook(club, bookInfo, user, ClubMemberRole.MEMBER);
     }
 
     // 클럽 멤버 삭제

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
@@ -65,7 +65,7 @@ public class ClubService {
                 .build();
         clubRepository.save(club);
         // 클럽 리더 생성
-        clubMemberService.createClubLeader(club, currentUser);
+        clubMemberService.createClubLeader(club, bookInfo, currentUser);
         return club.getClubId();
     }
 
@@ -158,6 +158,7 @@ public class ClubService {
     public Long joinClub(Long clubId, ClubJoinRequestDto requestDto) {
         User currentUser = userService.getCurrentUser();
         Club club = getClubById(clubId);
+        BookInfo bookInfo = club.getBookInfo();
 
         // 클럽 가입 허용 여부 확인
         if (!club.getAllowJoin()) {
@@ -173,7 +174,7 @@ public class ClubService {
         if (club.getPassword() != null && !club.getPassword().equals(requestDto.password())) {
             throw new CustomException(ErrorCode.CLUB_PASSWORD_INCORRECT);
         }
-        ClubMember clubMember = clubMemberService.joinToClub(club, currentUser);
+        ClubMember clubMember = clubMemberService.joinToClub(club, bookInfo, currentUser);
         return clubMember.getClubMemberId();
     }
 
@@ -237,7 +238,6 @@ public class ClubService {
     public ClubDetailResponseDto getClubDetail(Long clubId) {
         Club club = getClubById(clubId);
         int memberCount = Math.toIntExact(clubMemberService.countByClub(club));
-        // 멤버 여부 및 역할을 서비스에 위임
         User currentUser = userService.getCurrentUser();
         ClubMemberRoleInfo roleInfo = clubMemberService.getMemberRoleInfo(club, currentUser);
         return ClubDetailResponseDto.from(club, club.getBookInfo(), memberCount, roleInfo.isMember(), roleInfo.memberRole());


### PR DESCRIPTION
- 클럽 생성/가입 시 기존에 UserBook이 없는 경우 생성합니다. 있었다면 상태가 NOT_STARTED였을때만 READING으로 변경합니다.
- ClubBookInfoDto에 `@Schema(description = "커스텀책 여부") Boolean isCustom` 필드를 추가했습니다. 클럽 내 책 정보를 담는 dto이니 참고 부탁드립니다.
- 커스텀 북 상세보기 API에서 기존 친구는 조회 허용에서 모든 유저 조회 허용으로 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Club book details now indicate whether a book is custom.
  * Creating or joining a club automatically adds the selected book to your library and sets it to “Reading” (or updates “Not Started” → “Reading”).
  * Viewing custom books is now consistent: creators see full details (rating and one-line); other users see the shared basic view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->