### PR TITLE
[FEAT] 클럽 삭제를 비활성화가 아닌 실제 삭제로 변경, 다른 클럽 멤버가 있을 경우 삭제 불가능 로직 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/controller/ClubController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/controller/ClubController.java
@@ -71,7 +71,7 @@ public class ClubController {
         return ResponseEntity.ok(clubService.updateClub(clubId, requestDto));
     }
 
-    @Operation(summary = "클럽 삭제", description = "클럽 리더가 클럽을 삭제하거나 비활성화합니다.")
+    @Operation(summary = "클럽 삭제", description = "클럽 리더가 클럽을 삭제합니다. 클럽 멤버가 자신뿐일 때만 삭제가 가능합니다.")
     @DeleteMapping("/{clubId}")
     public ResponseEntity<Void> deleteClub(@PathVariable Long clubId) {
         clubService.deleteClub(clubId);

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/entity/ClubStatus.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/entity/ClubStatus.java
@@ -1,5 +1,5 @@
 package com.mmc.bookduck.domain.club.entity;
 
 public enum ClubStatus {
-    ACTIVE, ENDED, DELETED
+    ACTIVE, ENDED
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/repository/ClubMemberRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/repository/ClubMemberRepository.java
@@ -3,7 +3,11 @@ package com.mmc.bookduck.domain.club.repository;
 import com.mmc.bookduck.domain.club.entity.ClubMember;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.club.entity.Club;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +15,12 @@ import java.util.Optional;
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     boolean existsByClubAndUser(Club club, User user);
     Optional<ClubMember> findByClubAndUser(Club club, User user);
-    long countByClub(Club club);
     List<ClubMember> findByUser(User user);
     List<ClubMember> findByClub(Club club);
+    // 락 걸지 않음
+    long countByClub(Club club);
+    // 비관적 락
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select count(cm) from ClubMember cm where cm.club = :club")
+    long countForUpdateByClub(@Param("club") Club club);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
@@ -60,8 +60,7 @@ public class ClubMemberService {
             throw new CustomException(ErrorCode.ALREADY_JOINED_CLUB);
         }
         // 최대 인원 확인
-        int memberCount = Math.toIntExact(clubMemberRepository.countByClub(club));
-        if (memberCount >= club.getMaxMember()) {
+        if (club.getMaxMember() <= countForUpdateByClub(club)) {
             throw new CustomException(ErrorCode.CLUB_FULL);
         }
         // 클럽 가입
@@ -92,6 +91,11 @@ public class ClubMemberService {
     @Transactional(readOnly = true)
     public long countByClub(Club club) {
         return clubMemberRepository.countByClub(club);
+    }
+
+    // PESSIMISTIC_WRITE 락, @Transactional(readOnly = false) 필수
+    public long countForUpdateByClub(Club club) {
+        return clubMemberRepository.countForUpdateByClub(club);
     }
 
     @Transactional(readOnly = true)

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
@@ -284,7 +284,7 @@ public class ClubService {
         return ClubUpdateResponseDto.from(club);
     }
 
-    // 클럽 삭제 (비활성화)
+    // 클럽 삭제
     public void deleteClub(Long clubId) {
         Club club = getClubById(clubId);
 
@@ -296,9 +296,12 @@ public class ClubService {
             throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
         }
 
-        // 클럽 상태를 DELETED로 변경 (실제 삭제는 하지 않음)
-        club.updateStatus(ClubStatus.DELETED);
-        clubRepository.save(club);
+        // 클럽이 비어 있을 때만 삭제 가능
+        List<ClubMember> members = clubMemberService.getClubMembersByClub(club);
+        if (members.size() != 1 || !members.get(0).equals(member)) {
+            throw new CustomException(ErrorCode.CLUB_HAS_MEMBERS);
+        }
+        clubRepository.delete(club);
     }
 
     // 클럽 멤버 목록 조회

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
@@ -287,7 +287,6 @@ public class ClubService {
     // 클럽 삭제
     public void deleteClub(Long clubId) {
         Club club = getClubById(clubId);
-
         User currentUser = userService.getCurrentUser();
         ClubMember member = clubMemberService.getClubMemberByClubAndUser(club, currentUser);
 
@@ -297,10 +296,11 @@ public class ClubService {
         }
 
         // 클럽이 비어 있을 때만 삭제 가능
-        List<ClubMember> members = clubMemberService.getClubMembersByClub(club);
-        if (members.size() != 1 || !members.get(0).equals(member)) {
+        long memberCount = clubMemberService.countForUpdateByClub(club);
+        if (memberCount != 1L) {
             throw new CustomException(ErrorCode.CLUB_HAS_MEMBERS);
         }
+
         clubRepository.delete(club);
     }
 

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -34,7 +34,6 @@ public enum ErrorCode {
     CLUB_PASSWORD_INCORRECT(400, "클럽 비밀번호가 일치하지 않습니다."),
     INVALID_SORT_PARAMETER(400, "유효하지 않은 정렬 파라미터입니다."),
     INVALID_CLUB_STATUS(400, "유효하지 않은 클럽 상태 값입니다."),
-    CLUB_HAS_MEMBERS(400, "다른 클럽 멤버가 있어 클럽을 삭제할 수 없습니다."),
 
     // 401 Unauthorized
     // 로그인 상태여야 하는 요청
@@ -87,7 +86,7 @@ public enum ErrorCode {
     CLUB_MEMBER_NOT_FOUND(404, "북클럽 멤버를 찾을 수 없습니다."),
 
     // 409 Conflict
-    // 중복 리소스 생성 시도
+    // 중복 리소스 생성 시도, 서버의 현재 상태와 요청이 충돌했음
     USER_ALREADY_EXISTS(409, "이미 존재하는 사용자입니다."),
     NICKNAME_ALREADY_EXISTS(409, "이미 존재하는 닉네임입니다."),
     FRIEND_REQUEST_ALREADY_EXISTS(409, "이미 친구 요청이 존재합니다."),
@@ -105,6 +104,7 @@ public enum ErrorCode {
     ITEM_ALREADY_EXISTS(409, "이미 존재하는 아이템입니다."),
     ITEM_ALREADY_EQUIPPED(409, "이미 장착한 아이템입니다."),
     ALREADY_JOINED_CLUB(409, "이미 가입된 클럽입니다."),
+    CLUB_HAS_MEMBERS(409, "다른 클럽 멤버가 있어 클럽을 삭제할 수 없습니다."),
 
     // 500 Internal Server Error
     // 외부 API 사용 도중 에러

--- a/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/global/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.mmc.bookduck.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -35,6 +34,7 @@ public enum ErrorCode {
     CLUB_PASSWORD_INCORRECT(400, "클럽 비밀번호가 일치하지 않습니다."),
     INVALID_SORT_PARAMETER(400, "유효하지 않은 정렬 파라미터입니다."),
     INVALID_CLUB_STATUS(400, "유효하지 않은 클럽 상태 값입니다."),
+    CLUB_HAS_MEMBERS(400, "다른 클럽 멤버가 있어 클럽을 삭제할 수 없습니다."),
 
     // 401 Unauthorized
     // 로그인 상태여야 하는 요청


### PR DESCRIPTION
# 구현 기능
  - 클럽 삭제를 비활성화가 아닌 실제 DB 삭제로 변경했습니다. 이를 위해 ClubStatus에서 DELETED를 삭제하고, club 테이블 club_status ENUM 값도 변경했습니다.
  - 다른 클럽 멤버가 있을 경우 클럽 삭제가 불가능하도록 로직을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Club deletion now permanently removes clubs from the database.
  * Leaders can delete a club only if they are the sole member.
  * New validation error returned when attempting to delete a club with other members.
  * Improved concurrency handling for joining clubs to prevent race conditions and ensure accurate "club full" checks.
  * API documentation for the delete operation updated for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->