### PR TITLE
[FIX] 클럽 멤버 추가/클럽 삭제 시 클럽 멤버 수 동시성 제어 위해 native query로 락 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/repository/ClubMemberRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/repository/ClubMemberRepository.java
@@ -3,9 +3,7 @@ package com.mmc.bookduck.domain.club.repository;
 import com.mmc.bookduck.domain.club.entity.ClubMember;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.domain.club.entity.Club;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +16,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findByUser(User user);
     List<ClubMember> findByClub(Club club);
     long countByClub(Club club);
+    
+    @Query(value = "SELECT COUNT(*) FROM club_member WHERE club_id = :clubId FOR UPDATE", nativeQuery = true)
+    long countByClubForUpdate(@Param("clubId") Long clubId);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/repository/ClubMemberRepository.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/repository/ClubMemberRepository.java
@@ -16,7 +16,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findByUser(User user);
     List<ClubMember> findByClub(Club club);
     long countByClub(Club club);
-    
     @Query(value = "SELECT COUNT(*) FROM club_member WHERE club_id = :clubId FOR UPDATE", nativeQuery = true)
     long countByClubForUpdate(@Param("clubId") Long clubId);
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
@@ -119,4 +119,8 @@ public class ClubMemberService {
         return clubMemberRepository.findById(memberId)
                 .orElseThrow(()-> new CustomException(ErrorCode.CLUB_MEMBER_NOT_FOUND));
     }
+
+    public long countByClubForUpdate(Club club) {
+        return clubMemberRepository.countByClubForUpdate(club.getClubId());
+    }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubMemberService.java
@@ -14,6 +14,7 @@ import com.mmc.bookduck.domain.club.repository.ClubMemberRepository;
 import com.mmc.bookduck.domain.user.entity.User;
 import com.mmc.bookduck.global.exception.CustomException;
 import com.mmc.bookduck.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +30,7 @@ public class ClubMemberService {
     private final ClubMemberRepository clubMemberRepository;
     private final UserBookRepository userBookRepository;
     private final ClubMemberReadStatusRepository clubMemberReadStatusRepository;
+    private final EntityManager entityManager;
 
     // 클럽 멤버 생성
     private ClubMember createClubMemberAndAddUserBook(Club club, BookInfo bookInfo, User user, ClubMemberRole role) {
@@ -121,6 +123,7 @@ public class ClubMemberService {
     }
 
     public long countByClubForUpdate(Club club) {
+        entityManager.createNativeQuery("SET innodb_lock_wait_timeout = 3").executeUpdate();
         return clubMemberRepository.countByClubForUpdate(club.getClubId());
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
@@ -176,7 +176,7 @@ public class ClubService {
         }
 
         // 최대 인원 확인
-        if (club.getMaxMember() <= clubMemberService.countByClub(club)) {
+        if (club.getMaxMember() <= clubMemberService.countByClubForUpdate(club)) {
             throw new CustomException(ErrorCode.CLUB_FULL);
         }
         ClubMember clubMember = clubMemberService.addMemberToClub(club, bookInfo, currentUser);
@@ -286,7 +286,7 @@ public class ClubService {
         Club club = getClubByIdForUpdate(clubId);
         validateCurrentUserIsLeader(club);
         // 리더만 남아있을 때만 삭제 가능 (다른 멤버가 없어야 함)
-        long memberCount = clubMemberService.countByClub(club);
+        long memberCount = clubMemberService.countByClubForUpdate(club);
         if (memberCount != 1L) {
             throw new CustomException(ErrorCode.CLUB_HAS_MEMBERS);
         }


### PR DESCRIPTION
# 구현 기능
- 상황: Club 삭제 및 가입 시 countByClub() 호출 구간에서 동시 트랜잭션이 정원 초과, 또는 삭제 경쟁 상태를 유발할 수 있었음.
- 해결: Native query로 FOR UPDATE를 추가한 countByClubForUpdate() 메서드를 작성, ClubMember 행을 DB 수준에서 잠금 처리해 동시성 문제를 방지.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 여러 사용자가 동시에 클럽에 가입하거나 탈퇴할 때 멤버 수 집계 정확성을 개선했습니다.
  * 동시성 상황에서 클럽 입장(정원 확인) 및 클럽 삭제 시 멤버 수 검증이 보다 일관되게 처리되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->