### PR TITLE
[FIX] GET /clubs/{clubId}/archives에 memberId 추가

### DIFF
--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/controller/ClubController.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/controller/ClubController.java
@@ -114,11 +114,12 @@ public class ClubController {
         return ResponseEntity.ok(clubService.getJoinedClubs(clubStatus));
     }
 
-    @Operation(summary = "클럽 내 게시글 목록 조회", description = "클럽 내의 게시글이나 아카이브를 조회합니다.")
+    @Operation(summary = "클럽 내 게시글 목록 조회", description = "클럽 내의 게시글이나 아카이브를 조회합니다. memberId로 특정 멤버의 게시글만 필터링 가능합니다.")
     @GetMapping("/{clubId}/archives")
     public ResponseEntity<ClubArchiveListResponseDto> getClubArchives(
             @PathVariable Long clubId,
+            @RequestParam(required = false) Long memberId,
             Pageable pageable) {
-        return ResponseEntity.ok(clubService.getClubArchives(clubId, pageable));
+        return ResponseEntity.ok(clubService.getClubArchives(clubId, memberId, pageable));
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/dto/common/ClubMemberSummaryDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/dto/common/ClubMemberSummaryDto.java
@@ -1,0 +1,16 @@
+package com.mmc.bookduck.domain.club.dto.common;
+
+import com.mmc.bookduck.domain.club.entity.ClubMember;
+
+public record ClubMemberSummaryDto(
+        Long memberId,
+         String nickname
+) {
+    public static ClubMemberSummaryDto from(ClubMember member) {
+        return new ClubMemberSummaryDto(
+                member.getClubMemberId(),
+                member.getUser().getNickname()
+        );
+    }
+}
+

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/dto/response/ClubDetailResponseDto.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/dto/response/ClubDetailResponseDto.java
@@ -2,6 +2,7 @@ package com.mmc.bookduck.domain.club.dto.response;
 
 import com.mmc.bookduck.domain.book.entity.BookInfo;
 import com.mmc.bookduck.domain.club.dto.common.ClubBookInfoDto;
+import com.mmc.bookduck.domain.club.dto.common.ClubMemberSummaryDto;
 import com.mmc.bookduck.domain.club.entity.Club;
 import com.mmc.bookduck.domain.club.entity.ClubStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,6 +10,7 @@ import lombok.Builder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 @Schema(description = "클럽 상세 정보 응답 DTO")
@@ -27,9 +29,10 @@ public record ClubDetailResponseDto(
         @Schema(description = "책") ClubBookInfoDto clubBookInfo,
         @Schema(description = "현재 사용자의 멤버 여부") Boolean isMember,
         @Schema(description = "현재 사용자의 멤버 역할") String memberRole,
-        @Schema(description = "현재 사용자의 UserBook ID (없으면 null)") Long userBookId
+        @Schema(description = "현재 사용자의 UserBook ID (없으면 null)") Long userBookId,
+        @Schema(description = "클럽 멤버 목록 (ID, 닉네임)") List<ClubMemberSummaryDto> members
 ) {
-    public static ClubDetailResponseDto from(Club club, BookInfo bookInfo, Integer memberCount, boolean isMember, String memberRole, Long userBookId) {
+    public static ClubDetailResponseDto from(Club club, BookInfo bookInfo, Integer memberCount, boolean isMember, String memberRole, Long userBookId, List<ClubMemberSummaryDto> members) {
         return ClubDetailResponseDto.builder()
                 .clubId(club.getClubId())
                 .clubName(club.getClubName())
@@ -46,6 +49,7 @@ public record ClubDetailResponseDto(
                 .isMember(isMember)
                 .memberRole(memberRole)
                 .userBookId(userBookId)
+                .members(members)
                 .build();
     }
 }

--- a/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
+++ b/bookduck/src/main/java/com/mmc/bookduck/domain/club/service/ClubService.java
@@ -9,6 +9,7 @@ import com.mmc.bookduck.domain.book.entity.UserBook;
 import com.mmc.bookduck.domain.book.repository.UserBookRepository;
 import com.mmc.bookduck.domain.book.service.BookInfoService;
 import com.mmc.bookduck.domain.club.dto.common.ClubBookInfoDto;
+import com.mmc.bookduck.domain.club.dto.common.ClubMemberSummaryDto;
 import com.mmc.bookduck.domain.club.dto.common.ClubMemberRoleInfo;
 import com.mmc.bookduck.domain.club.dto.request.ClubCreateRequestDto;
 import com.mmc.bookduck.domain.club.dto.request.ClubJoinRequestDto;
@@ -73,7 +74,7 @@ public class ClubService {
     }
 
     @Transactional(readOnly = true)
-    public ClubArchiveListResponseDto getClubArchives(Long clubId, Pageable pageable) {
+    public ClubArchiveListResponseDto getClubArchives(Long clubId, Long memberId, Pageable pageable) {
         User currentUser = userService.getCurrentUser();
         Club club = getClubById(clubId);
         // 클럽 멤버 및 상태 조회
@@ -81,12 +82,21 @@ public class ClubService {
         LocalDateTime lastReadAt = markAsReadAndGetLastReadAt(currentMember);
         BookInfo targetBook = club.getBookInfo();
 
-        // 클럽 멤버 전체 userId 추출
-        List<Long> memberUserIds = clubMemberService.getClubMembersByClub(club).stream()
-                .map(cm -> cm.getUser().getUserId())
-                .toList();
+        List<Long> memberUserIds;
+        if (memberId != null) {
+            // 특정 멤버만 필터링
+            ClubMember targetMember = clubMemberService.getClubMemberById(memberId);
+            if (!targetMember.getClub().getClubId().equals(clubId)) {
+                throw new CustomException(ErrorCode.CLUB_MEMBER_NOT_FOUND);
+            }
+            memberUserIds = List.of(targetMember.getUser().getUserId());
+        } else {
+            // 전체 멤버
+            memberUserIds = clubMemberService.getClubMembersByClub(club).stream()
+                    .map(cm -> cm.getUser().getUserId())
+                    .toList();
+        }
 
-        // 전체 Excerpt / Review 조회 (읽음 여부 필터 제거)
         List<Excerpt> excerpts = excerptRepository.findClubExcerpts(
                 targetBook.getBookInfoId(),
                 memberUserIds,
@@ -246,7 +256,12 @@ public class ClubService {
                 .map(UserBook::getUserBookId)
                 .orElse(null);
         
-        return ClubDetailResponseDto.from(club, club.getBookInfo(), memberCount, roleInfo.isMember(), roleInfo.memberRole(), userBookId);
+        // 클럽 멤버 목록 조회
+        List<ClubMemberSummaryDto> members = clubMemberService.getClubMembersByClub(club).stream()
+                .map(ClubMemberSummaryDto::from)
+                .toList();
+        
+        return ClubDetailResponseDto.from(club, club.getBookInfo(), memberCount, roleInfo.isMember(), roleInfo.memberRole(), userBookId, members);
     }
 
     // LEADER만 수정/삭제 가능


### PR DESCRIPTION
# 구현 기능
  - GET /clubs/{clubId}/archives에 memberId 쿼리 파라미터 추가: 북클럽 필터 구현을 위해 필요

### 필요 페이지 화면
<img width="357" height="310" alt="image" src="https://github.com/user-attachments/assets/31eb9dbc-a804-4fbd-bc83-276b8624bed8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 클럽 아카이브 조회 시 특정 회원의 게시물로 필터링할 수 있는 기능 추가
  * 클럽 상세 정보에 회원 목록 정보 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->